### PR TITLE
Add logging for describeClusters API call

### DIFF
--- a/cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
+++ b/cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
@@ -90,6 +90,8 @@ public class ReadHandler extends BaseHandlerStd {
             final ProxyClient<RedshiftClient> proxyClient) {
         DescribeClustersResponse awsResponse = null;
         try {
+            logger.log(String.format("%s %s describeClusters.", ResourceModel.TYPE_NAME,
+                    awsRequest.clusterIdentifier()));
             awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::describeClusters);
         } catch (final ClusterNotFoundException e) {
             throw new CfnNotFoundException(ResourceModel.TYPE_NAME, awsRequest.clusterIdentifier(), e);


### PR DESCRIPTION
Add logging for desribeClusters API call in ReadHandler.

This PR is for registering AWS::Redshift::Cluster in 4 new regions (MXP HKG CPT BAH) for region expansion scheduled for Week 29.
