### PR TITLE
[ScheduledAction] Fix Contract Tests failure by overriding the ScheduledActionDescription

### DIFF
--- a/scheduledaction/overrides.json
+++ b/scheduledaction/overrides.json
@@ -2,6 +2,7 @@
     "CREATE": {
         "/Schedule": "cron(0 20 * * ? *)",
         "/IamRole": "{{RedshiftScheduledActionContractRole}}",
+        "/ScheduledActionDescription": "A Redshift Scheduled Action for CFN Contract Tests - CREATE",
         "/TargetAction": {
             "ResumeCluster": {
                 "ClusterIdentifier": "test-cluster-id"
@@ -13,6 +14,7 @@
     "UPDATE": {
         "/Schedule": "cron(0 20 * * ? *)",
         "/IamRole": "{{RedshiftScheduledActionContractRole}}",
+        "/ScheduledActionDescription": "A Redshift Scheduled Action for CFN Contract Tests - UPDATE",
         "/TargetAction": {
             "PauseCluster": {
                 "ClusterIdentifier": "test-cluster-id"


### PR DESCRIPTION
*Issue #, if available:*
Contract Tests may fail occasionally since it would not follow the regex definition in Schema to generate a correct string pattern for `ScheduledActionDescription` field.

*Description of changes:*
Define a fixed string pattern for `ScheduledActionDescription` by using the `override.json`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
