### PR TITLE
Fix ClusterSubnetGroup Contract Tests and cfn validate

### DIFF
--- a/clustersubnetgroup/README.md
+++ b/clustersubnetgroup/README.md
@@ -1,13 +1,28 @@
 # AWS::Redshift::ClusterSubnetGroup
-##Background
-This is new uluru resource is planned to replace the native resource in CloudFormation. It is developed following [uluru onboarding guide](https://w.amazon.com/bin/view/AWS21/Design/Uluru/Onboarding_Guide) Please refer to [redshift API](https://docs.aws.amazon.com/redshift/latest/APIReference/Welcome.html) when development.
 
-##Code generate
-The RPDK will automatically generate the correct resource model from the schema whenever the project is built via Maven. You can also do this manually with the following command: `cfn generate`.
+The code uses [Lombok](https://projectlombok.org/), and [you may have to install IDE integrations](https://projectlombok.org/setup/overview)
+to enable auto-complete for Lombok-annotated classes.
 
-> Please don't modify files under `target/generated-sources/rpdk`, as they will be automatically overwritten.
+## Contract Test
 
-The code uses [Lombok](https://projectlombok.org/), and [you may have to install IDE integrations](https://projectlombok.org/setup/overview) to enable auto-complete for Lombok-annotated classes.
-
-##Sam Test
-Create two subnets using one VPC first, these can be used to test construct the subnet group.
+1. Build the package
+   ```bash
+   mvn clean package
+   ```
+1. Run the contract test in your local
+    1. Initiate a SAM local virtual environment. Type in the following command to your terminal. Note: SAM local command will occupy the
+       terminal window.
+    ```bash
+    sam local start-lambda
+    ```
+    1. Perform the contract test
+    ```bash
+    cfn test --enforce-timeout 60
+    ```
+    1. If you ever want to perform any specific contract test item, use the following command instead.
+    ```bash
+    cfn test -- -k <Test-Name>
+    ```
+1. Modify the `overrides.json` to control the contract test input cases if necessary.
+1. For more information, please refer
+   to [Testing resource types locally using SAM](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test.html)

--- a/clustersubnetgroup/aws-redshift-clustersubnetgroup.json
+++ b/clustersubnetgroup/aws-redshift-clustersubnetgroup.json
@@ -6,6 +6,7 @@
         "Tag": {
             "description": "A key-value pair to associate with a resource.",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "Key": {
                     "type": "string",
@@ -34,6 +35,7 @@
         "SubnetIds": {
             "description": "The list of VPC subnet IDs",
             "type": "array",
+            "insertionOrder": false,
             "maxItems": 20,
             "items": {
                 "type": "string"
@@ -42,6 +44,7 @@
         "Tags": {
             "description": "The list of tags for the cluster parameter group.",
             "type": "array",
+            "insertionOrder": false,
             "maxItems": 50,
             "items": {
                 "$ref": "#/definitions/Tag"
@@ -50,7 +53,7 @@
         "ClusterSubnetGroupName": {
             "description": "This name must be unique for all subnet groups that are created by your AWS account. If costumer do not provide it, cloudformation will generate it. Must not be \"Default\". ",
             "type": "string",
-            "maximum": 255
+            "maxLength": 255
         }
     },
     "additionalProperties": false,
@@ -64,6 +67,9 @@
     "readOnlyProperties": [
         "/properties/ClusterSubnetGroupName"
     ],
+    "tagging": {
+        "taggable": true
+    },
     "handlers": {
         "create": {
             "permissions": [

--- a/clustersubnetgroup/docs/tag.md
+++ b/clustersubnetgroup/docs/tag.md
@@ -1,0 +1,53 @@
+# AWS::Redshift::ClusterSubnetGroup Tag
+
+A key-value pair to associate with a resource.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#key" title="Key">Key</a>" : <i>String</i>,
+    "<a href="#value" title="Value">Value</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#key" title="Key">Key</a>: <i>String</i>
+<a href="#value" title="Value">Value</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### Key
+
+The key name of the tag. You can specify a value that is 1 to 127 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>127</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Value
+
+The value for the tag. You can specify a value that is 1 to 255 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>255</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/clustersubnetgroup/overrides.json
+++ b/clustersubnetgroup/overrides.json
@@ -1,0 +1,16 @@
+{
+    "CREATE": {
+        "/Description": "Redshift ClusterSubnetGroup Contract Test",
+        "/SubnetIds": [
+            "{{RedshiftClusterSubnetGroupContractSubnet}}"
+        ],
+        "/Tags": []
+    },
+    "UPDATE": {
+        "/Description": "Redshift ClusterSubnetGroup Contract Test",
+        "/SubnetIds": [
+            "{{RedshiftClusterSubnetGroupContractSubnet1}}"
+        ],
+        "/Tags": []
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
- `cfn validate` did not pass
- The latest Contract Tests did not pass

*Description of changes:*
Fix Schema and add `overrides.json` to pass `cfn validate` and Contract Tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
