### PR TITLE
Add properties ClusterIdentifier and SubnetGroupName as `required` for EndpointAccess

### DIFF
--- a/aws-redshift-endpointaccess/aws-redshift-endpointaccess.json
+++ b/aws-redshift-endpointaccess/aws-redshift-endpointaccess.json
@@ -123,6 +123,8 @@
     },
     "additionalProperties": false,
     "required": [
+        "ClusterIdentifier",
+        "SubnetGroupName",
         "EndpointName",
         "VpcSecurityGroupIds"
     ],

--- a/aws-redshift-endpointaccess/docs/README.md
+++ b/aws-redshift-endpointaccess/docs/README.md
@@ -40,7 +40,7 @@ Properties:
 
 A unique identifier for the cluster. You use this identifier to refer to the cluster for any subsequent cluster operations such as deleting or modifying. All alphabetical characters must be lower case, no hypens at the end, no two consecutive hyphens. Cluster name should be unique for all clusters within an AWS account
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -74,7 +74,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 The subnet group name where Amazon Redshift chooses to deploy the endpoint.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 


### PR DESCRIPTION
*Issue #, if available:*
- `ClusterIdentifier` and `SubnetGroupName` are required by the Front-End

*Description of changes:*
- Put both properties to `required` field

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
