### PR TITLE
Update cluster IAM roles to 50 from 10

### DIFF
--- a/aws-redshift-cluster/aws-redshift-cluster.json
+++ b/aws-redshift-cluster/aws-redshift-cluster.json
@@ -153,10 +153,10 @@
             }
         },
         "IamRoles": {
-            "description": "A list of AWS Identity and Access Management (IAM) roles that can be used by the cluster to access other AWS services. You must supply the IAM roles in their Amazon Resource Name (ARN) format. You can supply up to 10 IAM roles in a single request",
+            "description": "A list of AWS Identity and Access Management (IAM) roles that can be used by the cluster to access other AWS services. You must supply the IAM roles in their Amazon Resource Name (ARN) format. You can supply up to 50 IAM roles in a single request",
             "type": "array",
             "insertionOrder": false,
-            "maxItems": 10,
+            "maxItems": 50,
             "items": {
                 "type": "string"
             }

--- a/aws-redshift-cluster/docs/README.md
+++ b/aws-redshift-cluster/docs/README.md
@@ -355,7 +355,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### IamRoles
 
-A list of AWS Identity and Access Management (IAM) roles that can be used by the cluster to access other AWS services. You must supply the IAM roles in their Amazon Resource Name (ARN) format. You can supply up to 10 IAM roles in a single request
+A list of AWS Identity and Access Management (IAM) roles that can be used by the cluster to access other AWS services. You must supply the IAM roles in their Amazon Resource Name (ARN) format. You can supply up to 50 IAM roles in a single request
 
 _Required_: No
 

--- a/aws-redshift-cluster/pom.xml
+++ b/aws-redshift-cluster/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>redshift</artifactId>
-            <version>2.17.4</version>
+            <version>2.18.31</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
[Description/Design]:

Update cluster IAM roles to 50 from 10. it was changed to 50 : According to the config read by the coral service default value is set to 50, hence there are no limitation from the API side. https://code.amazon.com/packages/RedshiftConfigurations/blobs/mainline/--/configuration/RedshiftConfigurations/ServerConfigurations/CORAL_SERVICE/CoralService.yml#L283. Add new redshift SDK version dependency in POM file  to support above change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
