### PR TITLE
[Fix] ClusterParameterGroup would only reset/update only if needed

### DIFF
--- a/aws-redshift-clusterparametergroup/docs/tag.md
+++ b/aws-redshift-clusterparametergroup/docs/tag.md
@@ -32,9 +32,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -46,6 +46,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/UpdateHandler.java
+++ b/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/UpdateHandler.java
@@ -81,8 +81,7 @@ public class UpdateHandler extends BaseHandlerStd {
                         .translateToServiceRequest(Translator::translateToResetRequest)
                         .makeServiceCall(this::resetClusterParameterGroup)
                         .handleError(this::resetClusterParameterGroupErrorHandler)
-                        .progress()
-                )
+                        .progress())
 
                 .then(progress -> proxy.initiate("AWS-Redshift-ClusterParameterGroup::Update::UpdateParameters", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
                         .translateToServiceRequest(Translator::translateToUpdateRequest)

--- a/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/UpdateHandler.java
+++ b/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/UpdateHandler.java
@@ -1,9 +1,12 @@
 package software.amazon.redshift.clusterparametergroup;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.awssdk.services.redshift.model.ClusterParameterGroupNotFoundException;
 import software.amazon.awssdk.services.redshift.model.CreateTagsResponse;
+import software.amazon.awssdk.services.redshift.model.DescribeClusterParametersRequest;
+import software.amazon.awssdk.services.redshift.model.DescribeClusterParametersResponse;
 import software.amazon.awssdk.services.redshift.model.DescribeTagsRequest;
 import software.amazon.awssdk.services.redshift.model.DescribeTagsResponse;
 import software.amazon.awssdk.services.redshift.model.InvalidClusterParameterGroupStateException;
@@ -22,7 +25,12 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 public class UpdateHandler extends BaseHandlerStd {
+    public static final String NEED_TO_BE_RESET = "needToBeReset";
     private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -36,45 +44,108 @@ public class UpdateHandler extends BaseHandlerStd {
         final String resourceName = String.format("arn:%s:redshift:%s:%s:parametergroup:%s", request.getAwsPartition(), request.getRegion(), request.getAwsAccountId(), request.getDesiredResourceState().getParameterGroupName());
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
-                .then(progress ->
-                        proxy.initiate("AWS-Redshift-EventSubscription::Update::ReadTags", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                                .translateToServiceRequest(resourceModel -> Translator.translateToReadTagsRequest(resourceName))
-                                .makeServiceCall(this::readTags)
-                                .handleError(this::operateTagsErrorHandler)
-                                .done((tagsRequest, tagsResponse, client, model, context) -> ProgressEvent.<ResourceModel, CallbackContext>builder()
-                                        .callbackContext(callbackContext)
-                                        .callbackDelaySeconds(0)
-                                        .resourceModel(Translator.translateFromReadTagsResponse(tagsResponse))
-                                        .status(OperationStatus.IN_PROGRESS)
-                                        .build()))
+                .then(progress -> proxy.initiate("AWS-Redshift-EventSubscription::Update::ReadTags", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                        .translateToServiceRequest(resourceModel -> Translator.translateToReadTagsRequest(resourceName))
+                        .makeServiceCall(this::readTags)
+                        .handleError(this::operateTagsErrorHandler)
+                        .done((tagsRequest, tagsResponse, client, model, context) -> ProgressEvent.<ResourceModel, CallbackContext>builder()
+                                .callbackContext(callbackContext)
+                                .callbackDelaySeconds(0)
+                                .resourceModel(Translator.translateFromReadTagsResponse(tagsResponse))
+                                .status(OperationStatus.IN_PROGRESS)
+                                .build()))
 
-                .then(progress ->
-                        proxy.initiate("AWS-Redshift-EventSubscription::Update::UpdateTags", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                                .translateToServiceRequest(resourceModel -> Translator.translateToUpdateTagsRequest(request.getDesiredResourceState(), resourceModel, resourceName))
-                                .makeServiceCall(this::updateTags)
-                                .handleError(this::operateTagsErrorHandler)
-                                .done((tagsRequest, tagsResponse, client, model, context) -> ProgressEvent.<ResourceModel, CallbackContext>builder()
-                                        .callbackContext(callbackContext)
-                                        .callbackDelaySeconds(0)
-                                        .resourceModel(request.getDesiredResourceState())
-                                        .status(OperationStatus.IN_PROGRESS)
-                                        .build()))
+                .then(progress -> proxy.initiate("AWS-Redshift-EventSubscription::Update::UpdateTags", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                        .translateToServiceRequest(resourceModel -> Translator.translateToUpdateTagsRequest(request.getDesiredResourceState(), resourceModel, resourceName))
+                        .makeServiceCall(this::updateTags)
+                        .handleError(this::operateTagsErrorHandler)
+                        .done((tagsRequest, tagsResponse, client, model, context) -> ProgressEvent.<ResourceModel, CallbackContext>builder()
+                                .callbackContext(callbackContext)
+                                .callbackDelaySeconds(0)
+                                .resourceModel(request.getDesiredResourceState())
+                                .status(OperationStatus.IN_PROGRESS)
+                                .build()))
 
-                .then(progress -> proxy.initiate("AWS-Redshift-ClusterParameterGroup::Update::ResetInstance", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                .then(progress -> proxy.initiate("AWS-RedshiftServerless-Workgroup::Update::ReadParameters", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                        .translateToServiceRequest(Translator::translateToReadParametersRequest)
+                        .makeServiceCall(this::describeClusterParameters)
+                        .handleError(this::describeClusterParametersErrorHandler)
+                        .done((readRequest, readResponse, client, model, context) -> ProgressEvent.<ResourceModel, CallbackContext>builder()
+                                .callbackContext(context)
+                                .callbackDelaySeconds(0)
+                                .resourceModel(getUpdatableResourceModel(model, Translator.translateFromReadParametersResponse(readResponse, model)))
+                                .status(OperationStatus.IN_PROGRESS)
+                                .build()))
+
+                .then(progress -> proxy.initiate("AWS-Redshift-ClusterParameterGroup::Update::ResetParameters", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
                         .translateToServiceRequest(Translator::translateToResetRequest)
                         .makeServiceCall(this::resetClusterParameterGroup)
                         .handleError(this::resetClusterParameterGroupErrorHandler)
                         .progress()
                 )
 
-                .then(progress -> CollectionUtils.isEmpty(progress.getResourceModel().getParameters()) ? progress :
-                        proxy.initiate("AWS-Redshift-ClusterParameterGroup::Update::UpdateInstance", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
-                                .translateToServiceRequest(Translator::translateToUpdateRequest)
-                                .makeServiceCall(this::modifyClusterParameterGroup)
-                                .handleError(this::modifyClusterParameterGroupErrorHandler)
-                                .progress())
+                .then(progress -> proxy.initiate("AWS-Redshift-ClusterParameterGroup::Update::UpdateParameters", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+                        .translateToServiceRequest(Translator::translateToUpdateRequest)
+                        .makeServiceCall(this::modifyClusterParameterGroup)
+                        .handleError(this::modifyClusterParameterGroupErrorHandler)
+                        .progress())
 
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+    }
+
+    private ResourceModel getUpdatableResourceModel(ResourceModel desiredModel, ResourceModel previousModel) {
+        List<Parameter> desiredParameters = desiredModel.getParameters()
+                .stream()
+                .map(parameter -> Parameter.builder()
+                        .parameterName(StringUtils.lowerCase(parameter.getParameterName()))
+                        .parameterValue(parameter.getParameterValue())
+                        .build())
+                .collect(Collectors.toList());
+
+        List<Parameter> previousParameters = previousModel.getParameters()
+                .stream()
+                .map(parameter -> Parameter.builder()
+                        .parameterName(StringUtils.lowerCase(parameter.getParameterName()))
+                        .parameterValue(parameter.getParameterValue())
+                        .build())
+                .collect(Collectors.toList());
+
+        return desiredModel.toBuilder()
+                .parameters(CollectionUtils.disjunction(desiredParameters, previousParameters)
+                        .stream()
+                        .map(parameter -> desiredParameters
+                                .stream()
+                                .filter(d -> StringUtils.equalsIgnoreCase(d.getParameterName(), parameter.getParameterName()))
+                                .findAny()
+                                .orElse(Parameter.builder()
+                                        .parameterName(parameter.getParameterName())
+                                        .parameterValue(NEED_TO_BE_RESET)
+                                        .build()))
+                        .distinct()
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    private DescribeClusterParametersResponse describeClusterParameters(final DescribeClusterParametersRequest awsRequest,
+                                                                        final ProxyClient<RedshiftClient> proxyClient) {
+        DescribeClusterParametersResponse awsResponse;
+        awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::describeClusterParameters);
+
+        logger.log(String.format("%s's Parameters has successfully been read.", ResourceModel.TYPE_NAME));
+        return awsResponse;
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> describeClusterParametersErrorHandler(final DescribeClusterParametersRequest awsRequest,
+                                                                                                final Exception exception,
+                                                                                                final ProxyClient<RedshiftClient> client,
+                                                                                                final ResourceModel model,
+                                                                                                final CallbackContext context) {
+        if (exception instanceof ClusterParameterGroupNotFoundException) {
+            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.NotFound);
+
+        } else {
+            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.GeneralServiceException);
+        }
     }
 
     private DescribeTagsResponse readTags(final DescribeTagsRequest awsRequest,
@@ -128,11 +199,19 @@ public class UpdateHandler extends BaseHandlerStd {
 
     private ResetClusterParameterGroupResponse resetClusterParameterGroup(final ResetClusterParameterGroupRequest awsRequest,
                                                                           final ProxyClient<RedshiftClient> proxyClient) {
-        ResetClusterParameterGroupResponse awsResponse;
-        awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::resetClusterParameterGroup);
+        return Optional.of(awsRequest)
+                .filter(r -> !CollectionUtils.isEmpty(r.parameters()))
+                .map(r -> {
+                    ResetClusterParameterGroupResponse awsResponse;
+                    awsResponse = proxyClient.injectCredentialsAndInvokeV2(r, proxyClient.client()::resetClusterParameterGroup);
 
-        logger.log(String.format("%s has successfully been reset.", ResourceModel.TYPE_NAME));
-        return awsResponse;
+                    logger.log(String.format("%s's Parameters has successfully been reset.", ResourceModel.TYPE_NAME));
+                    return awsResponse;
+                })
+                .orElseGet(() -> {
+                    logger.log(String.format("%s's Parameters has nothing to be reset.", ResourceModel.TYPE_NAME));
+                    return ResetClusterParameterGroupResponse.builder().build();
+                });
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> resetClusterParameterGroupErrorHandler(final ResetClusterParameterGroupRequest awsRequest,
@@ -153,11 +232,19 @@ public class UpdateHandler extends BaseHandlerStd {
 
     private ModifyClusterParameterGroupResponse modifyClusterParameterGroup(final ModifyClusterParameterGroupRequest awsRequest,
                                                                             final ProxyClient<RedshiftClient> proxyClient) {
-        ModifyClusterParameterGroupResponse awsResponse;
-        awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::modifyClusterParameterGroup);
+        return Optional.of(awsRequest)
+                .filter(r -> !CollectionUtils.isEmpty(r.parameters()))
+                .map(r -> {
+                    ModifyClusterParameterGroupResponse awsResponse;
+                    awsResponse = proxyClient.injectCredentialsAndInvokeV2(r, proxyClient.client()::modifyClusterParameterGroup);
 
-        logger.log(String.format("%s has successfully been updated.", ResourceModel.TYPE_NAME));
-        return awsResponse;
+                    logger.log(String.format("%s's Parameters has successfully been updated.", ResourceModel.TYPE_NAME));
+                    return awsResponse;
+                })
+                .orElseGet(() -> {
+                    logger.log(String.format("%s's Parameters has nothing to be updated.", ResourceModel.TYPE_NAME));
+                    return ModifyClusterParameterGroupResponse.builder().build();
+                });
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> modifyClusterParameterGroupErrorHandler(final ModifyClusterParameterGroupRequest awsRequest,

--- a/aws-redshift-clusterparametergroup/src/test/java/software/amazon/redshift/clusterparametergroup/ReadHandlerTest.java
+++ b/aws-redshift-clusterparametergroup/src/test/java/software/amazon/redshift/clusterparametergroup/ReadHandlerTest.java
@@ -67,7 +67,6 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
-        System.out.println("Read response is:: " + response);
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);


### PR DESCRIPTION
*Issue #, if available:*
- Originally, we reset/update all parameters if the Update Handler is called, regardless of whether they're required to be reset/update indeed or not. This logic result in unnecessarily cluster reboot after the update.

*Description of changes:*
- We change the log to only reset/update specific parameters if needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
