### PR TITLE
Detect EnhancedVpcRouting attribute change in modifyClusterRequest

### DIFF
--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/TestUtils.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/TestUtils.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.services.redshift.model.ClusterIamRole;
 import software.amazon.awssdk.services.redshift.model.ClusterSecurityGroupMembership;
 import software.amazon.awssdk.services.redshift.model.VpcSecurityGroupMembership;
 
+import java.lang.reflect.Field;
 import java.util.LinkedList;
 
 public class TestUtils {
@@ -75,5 +76,15 @@ public class TestUtils {
             .vpcSecurityGroupIds(new LinkedList<String>())
             .tags(new LinkedList<Tag>())
             .build();
+
+    public static <T> void modifyAttribute(T object, Class<T> clazz, String attributeName, Object attributeValue) throws Exception {
+        try {
+            Field field = clazz.getDeclaredField(attributeName);
+            field.setAccessible(true);
+            field.set(object, attributeValue);
+        } catch (NoSuchFieldException noSuchFieldException) {
+            return;
+        }
+    }
 
 }


### PR DESCRIPTION
The previous refactor change accidentally removes EnhandcedVpcRouting, this commit adds this attribute back, so its changes in Cluster model will be detected.

This commit also adds unit test to ensure all attributes for detecting modifyCluster are present

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
