### PR TITLE
Stop drift detecting cluster classic property

### DIFF
--- a/aws-redshift-cluster/aws-redshift-cluster.json
+++ b/aws-redshift-cluster/aws-redshift-cluster.json
@@ -304,7 +304,8 @@
         "/properties/MasterUsername"
     ],
     "writeOnlyProperties": [
-        "/properties/MasterUserPassword"
+        "/properties/MasterUserPassword",
+        "/properties/Classic"
     ],
     "tagging": {
         "taggable": true


### PR DESCRIPTION
https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1204

Classic property indicates whether the resize operation is using the classic resize. It's added to ease cloudformation template to indicate classic resize. describe-clusters used in drift will not indicate this property and hence this property once used in updating should be removed.

This commit adds this classic to "writeOnlyProperties". CFN drift detection doesn't check on writeOnlyProperties.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
