### PR TITLE
Add permission for CFN Contract Test

### DIFF
--- a/aws-redshift-cluster/aws-redshift-cluster.json
+++ b/aws-redshift-cluster/aws-redshift-cluster.json
@@ -316,7 +316,8 @@
                 "redshift:DescribeClusters",
                 "redshift:CreateCluster",
                 "redshift:RestoreFromClusterSnapshot",
-                "redshift:EnableLogging"
+                "redshift:EnableLogging",
+                "redshift:DescribeTags"
             ],
             "timeoutInMinutes": 2160
         },
@@ -325,7 +326,8 @@
                 "redshift:DescribeClusters",
                 "redshift:DescribeLoggingStatus",
                 "redshift:DescribeSnapshotCopyGrant",
-                "redshift:DescribeClusterDbRevisions"
+                "redshift:DescribeClusterDbRevisions",
+                "redshift:DescribeTags"
             ]
         },
         "update": {
@@ -336,6 +338,7 @@
                 "redshift:EnableLogging",
                 "redshift:CreateTags",
                 "redshift:DeleteTags",
+                "redshift:DescribeTags",
                 "redshift:DisableLogging",
                 "redshift:RebootCluster",
                 "redshift:EnableSnapshotCopy",
@@ -354,6 +357,7 @@
         },
         "delete": {
             "permissions": [
+                "redshift:DescribeTags",
                 "redshift:DescribeClusters",
                 "redshift:DeleteCluster"
             ],
@@ -361,6 +365,7 @@
         },
         "list": {
             "permissions": [
+                "redshift:DescribeTags",
                 "redshift:DescribeClusters"
             ]
         }

--- a/aws-redshift-clusterparametergroup/aws-redshift-clusterparametergroup.json
+++ b/aws-redshift-clusterparametergroup/aws-redshift-clusterparametergroup.json
@@ -102,6 +102,7 @@
                 "redshift:CreateClusterParameterGroup",
                 "redshift:ModifyClusterParameterGroup",
                 "redshift:DescribeClusterParameterGroups",
+                "redshift:DescribeTags",
                 "redshift:CreateTags",
                 "ec2:AllocateAddress",
                 "ec2:AssociateAddress",
@@ -118,11 +119,13 @@
         "read": {
             "permissions": [
                 "redshift:DescribeClusterParameterGroups",
-                "initech:DescribeReport"
+                "initech:DescribeReport",
+                "redshift:DescribeTags"
             ]
         },
         "update": {
             "permissions": [
+                "redshift:DescribeClusterParameterGroups",
                 "redshift:ResetClusterParameterGroup",
                 "redshift:ModifyClusterParameterGroup",
                 "redshift:DescribeTags",
@@ -133,12 +136,15 @@
         },
         "delete": {
             "permissions": [
+                "redshift:DescribeTags",
+                "redshift:DescribeClusterParameterGroups",
                 "redshift:DeleteClusterParameterGroup",
                 "initech:DeleteReport"
             ]
         },
         "list": {
             "permissions": [
+                "redshift:DescribeTags",
                 "redshift:DescribeClusterParameterGroups",
                 "initech:ListReports"
             ]

--- a/aws-redshift-clustersubnetgroup/aws-redshift-clustersubnetgroup.json
+++ b/aws-redshift-clustersubnetgroup/aws-redshift-clustersubnetgroup.json
@@ -80,6 +80,8 @@
             "permissions": [
                 "redshift:CreateClusterSubnetGroup",
                 "redshift:CreateTags",
+                "redshift:DescribeClusterSubnetGroups",
+                "redshift:DescribeTags",
                 "ec2:AllocateAddress",
                 "ec2:AssociateAddress",
                 "ec2:AttachNetworkInterface",
@@ -95,6 +97,7 @@
         "read": {
             "permissions": [
                 "redshift:DescribeClusterSubnetGroups",
+                "redshift:DescribeTags",
                 "ec2:AllocateAddress",
                 "ec2:AssociateAddress",
                 "ec2:AttachNetworkInterface",
@@ -110,6 +113,7 @@
         "update": {
             "permissions": [
                 "redshift:ModifyClusterSubnetGroup",
+                "redshift:DescribeClusterSubnetGroups",
                 "redshift:DescribeTags",
                 "redshift:CreateTags",
                 "redshift:DeleteTags",
@@ -128,6 +132,8 @@
         "delete": {
             "permissions": [
                 "redshift:DeleteClusterSubnetGroup",
+                "redshift:DescribeClusterSubnetGroups",
+                "redshift:DescribeTags",
                 "ec2:AllocateAddress",
                 "ec2:AssociateAddress",
                 "ec2:AttachNetworkInterface",
@@ -143,6 +149,7 @@
         "list": {
             "permissions": [
                 "redshift:DescribeClusterSubnetGroups",
+                "redshift:DescribeTags",
                 "ec2:AllocateAddress",
                 "ec2:AssociateAddress",
                 "ec2:AttachNetworkInterface",

--- a/aws-redshift-endpointaccess/aws-redshift-endpointaccess.json
+++ b/aws-redshift-endpointaccess/aws-redshift-endpointaccess.json
@@ -157,6 +157,7 @@
         "create": {
             "permissions": [
                 "redshift:CreateEndpointAccess",
+                "redshift:DescribeEndpointAccess",
                 "ec2:CreateClientVpnEndpoint",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeSecurityGroups",
@@ -179,6 +180,7 @@
         },
         "update": {
             "permissions": [
+                "redshift:DescribeEndpointAccess",
                 "redshift:ModifyEndpointAccess",
                 "ec2:ModifyClientVpnEndpoint",
                 "ec2:DescribeVpcAttribute",
@@ -192,6 +194,7 @@
         "delete": {
             "permissions": [
                 "redshift:DeleteEndpointAccess",
+                "redshift:DescribeEndpointAccess",
                 "ec2:DeleteClientVpnEndpoint",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeSecurityGroups",

--- a/aws-redshift-endpointauthorization/aws-redshift-endpointauthorization.json
+++ b/aws-redshift-endpointauthorization/aws-redshift-endpointauthorization.json
@@ -103,7 +103,8 @@
     "handlers": {
         "create": {
             "permissions": [
-                "redshift:AuthorizeEndpointAccess"
+                "redshift:AuthorizeEndpointAccess",
+                "redshift:DescribeEndpointAuthorization"
             ],
             "timeoutInMinutes": 60
         },
@@ -115,6 +116,7 @@
         "update": {
             "permissions": [
                 "redshift:AuthorizeEndpointAccess",
+                "redshift:DescribeEndpointAuthorization",
                 "redshift:RevokeEndpointAccess"
             ],
             "timeoutInMinutes": 60
@@ -123,6 +125,7 @@
             "permissions": [
                 "redshift:RevokeEndpointAccess",
                 "redshift:DeleteEndpointAccess",
+                "redshift:DescribeEndpointAuthorization",
                 "ec2:DeleteClientVpnEndpoint",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeSecurityGroups",

--- a/aws-redshift-eventsubscription/aws-redshift-eventsubscription.json
+++ b/aws-redshift-eventsubscription/aws-redshift-eventsubscription.json
@@ -161,7 +161,9 @@
         "create": {
             "permissions": [
                 "redshift:CreateEventSubscription",
-                "redshift:CreateTags"
+                "redshift:CreateTags",
+                "redshift:DescribeTags",
+                "redshift:DescribeEventSubscriptions"
             ]
         },
         "read": {
@@ -175,17 +177,21 @@
                 "redshift:ModifyEventSubscription",
                 "redshift:CreateTags",
                 "redshift:DescribeTags",
+                "redshift:DescribeEventSubscriptions",
                 "redshift:DeleteTags"
             ]
         },
         "delete": {
             "permissions": [
+                "redshift:DescribeEventSubscriptions",
                 "redshift:DeleteEventSubscription",
+                "redshift:DescribeTags",
                 "redshift:DeleteTags"
             ]
         },
         "list": {
             "permissions": [
+                "redshift:DescribeTags",
                 "redshift:DescribeEventSubscriptions"
             ]
         }

--- a/aws-redshift-scheduledaction/aws-redshift-scheduledaction.json
+++ b/aws-redshift-scheduledaction/aws-redshift-scheduledaction.json
@@ -160,6 +160,8 @@
         "create": {
             "permissions": [
                 "redshift:CreateScheduledAction",
+                "redshift:DescribeScheduledActions",
+                "redshift:DescribeTags",
                 "redshift:PauseCluster",
                 "redshift:ResumeCluster",
                 "redshift:ResizeCluster",
@@ -168,25 +170,31 @@
         },
         "read": {
             "permissions": [
-                "redshift:DescribeScheduledActions"
+                "redshift:DescribeScheduledActions",
+                "redshift:DescribeTags"
             ]
         },
         "update": {
             "permissions": [
+                "redshift:DescribeScheduledActions",
                 "redshift:ModifyScheduledAction",
                 "redshift:PauseCluster",
                 "redshift:ResumeCluster",
                 "redshift:ResizeCluster",
+                "redshift:DescribeTags",
                 "iam:PassRole"
             ]
         },
         "delete": {
             "permissions": [
+                "redshift:DescribeTags",
+                "redshift:DescribeScheduledActions",
                 "redshift:DeleteScheduledAction"
             ]
         },
         "list": {
             "permissions": [
+                "redshift:DescribeTags",
                 "redshift:DescribeScheduledActions"
             ]
         }


### PR DESCRIPTION
Most of the failing contract tests right now are because we didn't give CFN permission to call describeResource or describeTags APIs.

This commit gives the CFN those permissions in every handler, in case in the future CFN tests start requiring more read permissions again and break the existing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
