### PR TITLE
Add redshift:DescribeClusterParameters for contract test

### DIFF
--- a/aws-redshift-clusterparametergroup/aws-redshift-clusterparametergroup.json
+++ b/aws-redshift-clusterparametergroup/aws-redshift-clusterparametergroup.json
@@ -102,6 +102,7 @@
                 "redshift:CreateClusterParameterGroup",
                 "redshift:ModifyClusterParameterGroup",
                 "redshift:DescribeClusterParameterGroups",
+                "redshift:DescribeClusterParameters",
                 "redshift:DescribeTags",
                 "redshift:CreateTags",
                 "ec2:AllocateAddress",
@@ -120,6 +121,7 @@
             "permissions": [
                 "redshift:DescribeClusterParameterGroups",
                 "initech:DescribeReport",
+                "redshift:DescribeClusterParameters",
                 "redshift:DescribeTags"
             ]
         },
@@ -128,6 +130,7 @@
                 "redshift:DescribeClusterParameterGroups",
                 "redshift:ResetClusterParameterGroup",
                 "redshift:ModifyClusterParameterGroup",
+                "redshift:DescribeClusterParameters",
                 "redshift:DescribeTags",
                 "redshift:CreateTags",
                 "redshift:DeleteTags",
@@ -139,6 +142,7 @@
                 "redshift:DescribeTags",
                 "redshift:DescribeClusterParameterGroups",
                 "redshift:DeleteClusterParameterGroup",
+                "redshift:DescribeClusterParameters",
                 "initech:DeleteReport"
             ]
         },
@@ -146,6 +150,7 @@
             "permissions": [
                 "redshift:DescribeTags",
                 "redshift:DescribeClusterParameterGroups",
+                "redshift:DescribeClusterParameters",
                 "initech:ListReports"
             ]
         }


### PR DESCRIPTION
The latest contract test handler requires DescribeClusterParameter permissions. This commit adds the permission

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
