### PR TITLE
Construct cluster ARN using correct partition

### DIFF
--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/Translator.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/Translator.java
@@ -1,7 +1,6 @@
 package software.amazon.redshift.cluster;
 
 import com.amazonaws.util.StringUtils;
-import com.google.common.collect.MapDifference;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.awssdk.services.redshift.model.AquaConfiguration;
@@ -21,8 +20,6 @@ import software.amazon.awssdk.services.redshift.model.DescribeClustersResponse;
 import software.amazon.awssdk.services.redshift.model.DescribeLoggingStatusRequest;
 import software.amazon.awssdk.services.redshift.model.DescribeLoggingStatusResponse;
 import software.amazon.awssdk.services.redshift.model.DescribeSnapshotCopyGrantsRequest;
-import software.amazon.awssdk.services.redshift.model.DescribeTagsRequest;
-import software.amazon.awssdk.services.redshift.model.DescribeTagsResponse;
 import software.amazon.awssdk.services.redshift.model.DisableLoggingRequest;
 import software.amazon.awssdk.services.redshift.model.DisableSnapshotCopyRequest;
 import software.amazon.awssdk.services.redshift.model.ElasticIpStatus;

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/TestUtils.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/TestUtils.java
@@ -3,7 +3,9 @@ package software.amazon.redshift.cluster;
 import software.amazon.awssdk.services.redshift.model.Cluster;
 import software.amazon.awssdk.services.redshift.model.ClusterIamRole;
 import software.amazon.awssdk.services.redshift.model.ClusterSecurityGroupMembership;
+import software.amazon.awssdk.services.redshift.model.ClusterSnapshotCopyStatus;
 import software.amazon.awssdk.services.redshift.model.VpcSecurityGroupMembership;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.lang.reflect.Field;
 import java.util.LinkedList;
@@ -24,8 +26,11 @@ public class TestUtils {
     final static String S3_KEY_PREFIX = "create";
     final static String RESOURCE_NAME_PREFIX = "arn:aws:redshift:";
     final static String OWNER_ACCOUNT_NO = "1111";
+    final static String AWS_PARTITION = "aws";
 
     final static Cluster BASIC_CLUSTER = Cluster.builder()
+            .clusterStatus("available")
+            .clusterAvailabilityStatus("Available")
             .clusterIdentifier(CLUSTER_IDENTIFIER)
             .masterUsername(MASTER_USERNAME)
             .nodeType(NODETYPE)
@@ -54,6 +59,7 @@ public class TestUtils {
             .manualSnapshotRetentionPeriod(1)
             .publiclyAccessible(false)
             .clusterSecurityGroups(new LinkedList<ClusterSecurityGroupMembership>())
+            .clusterSnapshotCopyStatus(ClusterSnapshotCopyStatus.builder().build())
             .iamRoles(new LinkedList<ClusterIamRole>())
             .vpcSecurityGroups(new LinkedList<VpcSecurityGroupMembership>())
             .build();
@@ -75,6 +81,12 @@ public class TestUtils {
             .iamRoles(new LinkedList<String>())
             .vpcSecurityGroupIds(new LinkedList<String>())
             .tags(new LinkedList<Tag>())
+            .build();
+
+    final static ResourceHandlerRequest<ResourceModel> BASIC_RESOURCE_HANDLER_REQUEST = ResourceHandlerRequest.<ResourceModel>builder()
+            .region(AWS_REGION)
+            .awsAccountId(AWS_ACCOUNT_ID)
+            .awsPartition(AWS_PARTITION)
             .build();
 
     public static <T> void modifyAttribute(T object, Class<T> clazz, String attributeName, Object attributeValue) throws Exception {


### PR DESCRIPTION
Before we were hardcoding the ARN partition to be "aws", and in Gov region ARN was not correctly built and APIs failed.

This commit creates the ARN based on the aws partition in the request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
