### PR TITLE
Construct cluster ARN using correct partition

### DIFF
--- a/aws-redshift-cluster/docs/README.md
+++ b/aws-redshift-cluster/docs/README.md
@@ -439,9 +439,9 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### SnapshotCopyRetentionPeriod
 
-The number of days to retain automated snapshots in the destination region after they are copied from the source region.
+The number of days to retain automated snapshots in the destination region after they are copied from the source region. 
 
- Default is 7.
+ Default is 7. 
 
  Constraints: Must be at least 1 and no more than 35.
 
@@ -649,3 +649,4 @@ Returns the <code>Port</code> value.
 #### Address
 
 Returns the <code>Address</code> value.
+

--- a/aws-redshift-cluster/docs/endpoint.md
+++ b/aws-redshift-cluster/docs/endpoint.md
@@ -17,3 +17,4 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 </pre>
 
 ## Properties
+

--- a/aws-redshift-cluster/docs/loggingproperties.md
+++ b/aws-redshift-cluster/docs/loggingproperties.md
@@ -37,3 +37,4 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-redshift-cluster/docs/tag.md
+++ b/aws-redshift-cluster/docs/tag.md
@@ -51,3 +51,4 @@ _Minimum Length_: <code>1</code>
 _Maximum Length_: <code>255</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-redshift-cluster/resource-role.yaml
+++ b/aws-redshift-cluster/resource-role.yaml
@@ -38,6 +38,7 @@ Resources:
                 - "redshift:DescribeClusters"
                 - "redshift:DescribeLoggingStatus"
                 - "redshift:DescribeSnapshotCopyGrant"
+                - "redshift:DescribeTags"
                 - "redshift:DisableLogging"
                 - "redshift:DisableSnapshotCopy"
                 - "redshift:EnableLogging"

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/UpdateHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/UpdateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.redshift.cluster;
 
+import com.amazonaws.arn.Arn;
 import com.amazonaws.util.CollectionUtils;;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.ObjectUtils;
@@ -109,8 +110,14 @@ public class UpdateHandler extends BaseHandlerStd {
                 .then(progress -> {
                     List<List<Tag>> updateTags = updateTags(request.getPreviousResourceState().getTags(), model.getTags());
 
-                    String resourceName = RESOURCE_NAME_PREFIX + request.getRegion() + ":" + request.getAwsAccountId() +
-                            ":cluster:" + model.getClusterIdentifier();
+                    final String resourceName = Arn.builder()
+                            .withService("redshift")
+                            .withPartition(request.getAwsPartition())
+                            .withAccountId(request.getAwsAccountId())
+                            .withRegion(request.getRegion())
+                            .withResource(String.format("cluster:%s", model.getClusterIdentifier()))
+                            .build()
+                            .toString();
 
                     if (!CollectionUtils.isNullOrEmpty(updateTags) && !CollectionUtils.isNullOrEmpty(updateTags.get(DELETE_TAGS_INDEX))) {
                         progress = proxy.initiate("AWS-Redshift-Cluster::DeleteTags", proxyClient, model, callbackContext)

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/TestUtils.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/TestUtils.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.services.redshift.model.Cluster;
 import software.amazon.awssdk.services.redshift.model.ClusterIamRole;
 import software.amazon.awssdk.services.redshift.model.ClusterSecurityGroupMembership;
 import software.amazon.awssdk.services.redshift.model.VpcSecurityGroupMembership;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.lang.reflect.Field;
 import java.util.LinkedList;
@@ -12,6 +13,7 @@ public class TestUtils {
     final static String AWS_REGION = "us-east-1";
     final static String DESCRIPTION = "description";
     final static String SUBNET_GROUP_NAME = "name";
+    final static String AWS_PARTITION = "aws";
     final static String AWS_ACCOUNT_ID ="1111";
     final static String CLUSTER_IDENTIFIER = "redshift-cluster-1";
     final static String CLUSTER_IDENTIFIER_COMPLETE = "redshift-cluster-2";
@@ -75,6 +77,12 @@ public class TestUtils {
             .iamRoles(new LinkedList<String>())
             .vpcSecurityGroupIds(new LinkedList<String>())
             .tags(new LinkedList<Tag>())
+            .build();
+
+    final static ResourceHandlerRequest<ResourceModel> BASIC_RESOURCE_HANDLER_REQUEST = ResourceHandlerRequest.<ResourceModel>builder()
+            .region(AWS_REGION)
+            .awsAccountId(AWS_ACCOUNT_ID)
+            .awsPartition(AWS_PARTITION)
             .build();
 
     public static <T> void modifyAttribute(T object, Class<T> clazz, String attributeName, Object attributeValue) throws Exception {


### PR DESCRIPTION
Before we were hardcoding the ARN partition to be "aws", and in Gov region ARN was not correctly built and APIs failed.

This commit creates the ARN based on the aws partition in the request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
