### PR TITLE
Prevent cluster drift detection on SnapshotIdentifier

### DIFF
--- a/aws-redshift-cluster/aws-redshift-cluster.json
+++ b/aws-redshift-cluster/aws-redshift-cluster.json
@@ -305,7 +305,8 @@
     ],
     "writeOnlyProperties": [
         "/properties/MasterUserPassword",
-        "/properties/Classic"
+        "/properties/Classic",
+        "/properties/SnapshotIdentifier"
     ],
     "tagging": {
         "taggable": true


### PR DESCRIPTION
Right now if users provide SnapshotIdentifier on the Cluster in CFN template, after its creation, drift detection will display the cluster's status as drifted. In this case, we restore the cluster from the snapshot provided, and the snapshot identifier should not be considered as part of the drift detection.

Adding it to writeOnly properties will prevent this from happening

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
