### PR TITLE
Wait 10 seconds after modify-cluster call

### DIFF
--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/UpdateHandlerTest.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/UpdateHandlerTest.java
@@ -44,8 +44,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -75,10 +78,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
     static UpdateHandler handler;
     @BeforeEach
     public void setup() {
-        handler = new UpdateHandler();
+        handler = spy(new UpdateHandler());
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         sdkClient = mock(RedshiftClient.class);
         proxyClient = MOCK_PROXY(proxy, sdkClient);
+        lenient().doNothing().when(handler).sleep(anyInt());
     }
 
     @AfterEach
@@ -432,6 +436,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client()).modifyCluster(any(ModifyClusterRequest.class));
 
         // todo: make tests more independent so we can add tests like this elsewhere
+        verify(handler).sleep(10);
         assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_SENSITIVE.length == 1);
         assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_INSENSITIVE.length == 17);
 


### PR DESCRIPTION
After the modify-cluster call, it takes 1 or more seconds for the ACTIVE cluster to be changed to MODIFYING, we used to call stabilizer right after the modify-cluster call, and stabilizer immediately returns that the cluster is ACTIVE, because the cluster didn't get a chance to be changed to be MODIFYING, which incorrectly tells CFN that the modify-cluster is done.

We wait for 10 seconds just to be on the safe side, it's longer than we need most of the time, but 10 seconds is acceptable because the modify-cluster usually takes minutes for the cluster to be ACTIVE again.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
