### PR TITLE
System level tags are not supported in Redshift 

### DIFF
--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/CreateHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/CreateHandler.java
@@ -90,7 +90,6 @@ public class CreateHandler extends BaseHandlerStd {
         Map<String, String> mergedTags = Maps.newHashMap();
 
         mergedTags.putAll(Optional.ofNullable(request.getDesiredResourceTags()).orElse(Collections.emptyMap()));
-        mergedTags.putAll(Optional.ofNullable(request.getSystemTags()).orElse(Collections.emptyMap()));
         mergedTags.putAll(Optional.ofNullable(convertedTags).orElse(Collections.emptyMap()));
 
         return ProgressEvent.progress(resourceModel, callbackContext)


### PR DESCRIPTION
We dont support adding system tags to of the form aws:<composite-service>:<key> = <value>. Tagris recommends you allow them to do that but it is up to the service. The composite service does not have a way to add a system tag on a resource from Redshift.
   
Another options would be whitelisted by tAgris to allow the system tags. For now, we are removing the support for the system tags

