### PR TITLE
Remove describeCluster call from CreateHandler

### DIFF
--- a/aws-redshift-cluster/aws-redshift-cluster.json
+++ b/aws-redshift-cluster/aws-redshift-cluster.json
@@ -301,7 +301,6 @@
         "/properties/ClusterIdentifier"
     ],
     "readOnlyProperties": [
-        "/properties/Id",
         "/properties/DeferMaintenanceIdentifier",
         "/properties/Endpoint/Port",
         "/properties/Endpoint/Address",
@@ -331,9 +330,25 @@
                 "redshift:CreateCluster",
                 "redshift:RestoreFromClusterSnapshot",
                 "redshift:EnableLogging",
+                "redshift:CreateTags",
                 "redshift:DescribeTags",
                 "redshift:GetResourcePolicy",
-                "redshift:PutResourcePolicy"
+                "redshift:PutResourcePolicy",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeAddresses",
+                "ec2:AssociateAddress",
+                "ec2:DisassociateAddress",
+                "ec2:CreateNetworkInterface",
+                "ec2:DeleteNetworkInterface",
+                "ec2:ModifyNetworkInterfaceAttribute",
+                "ec2:CreateVpcEndpoint",
+                "ec2:DeleteVpcEndpoints",
+                "ec2:DescribeVpcEndpoints",
+                "ec2:ModifyVpcEndpoint",
+                "iam:CreateServiceLinkedRole",
+                "cloudwatch:PutMetricData"
             ],
             "timeoutInMinutes": 2160
         },

--- a/aws-redshift-cluster/docs/README.md
+++ b/aws-redshift-cluster/docs/README.md
@@ -39,6 +39,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#vpcsecuritygroupids" title="VpcSecurityGroupIds">VpcSecurityGroupIds</a>" : <i>[ String, ... ]</i>,
         "<a href="#snapshotclusteridentifier" title="SnapshotClusterIdentifier">SnapshotClusterIdentifier</a>" : <i>String</i>,
         "<a href="#snapshotidentifier" title="SnapshotIdentifier">SnapshotIdentifier</a>" : <i>String</i>,
+        "<a href="#id" title="Id">Id</a>" : <i>String</i>,
         "<a href="#owneraccount" title="OwnerAccount">OwnerAccount</a>" : <i>String</i>,
         "<a href="#loggingproperties" title="LoggingProperties">LoggingProperties</a>" : <i><a href="loggingproperties.md">LoggingProperties</a></i>,
         "<a href="#endpoint" title="Endpoint">Endpoint</a>" : <i><a href="endpoint.md">Endpoint</a></i>,
@@ -102,6 +103,7 @@ Properties:
       - String</i>
     <a href="#snapshotclusteridentifier" title="SnapshotClusterIdentifier">SnapshotClusterIdentifier</a>: <i>String</i>
     <a href="#snapshotidentifier" title="SnapshotIdentifier">SnapshotIdentifier</a>: <i>String</i>
+    <a href="#id" title="Id">Id</a>: <i>String</i>
     <a href="#owneraccount" title="OwnerAccount">OwnerAccount</a>: <i>String</i>
     <a href="#loggingproperties" title="LoggingProperties">LoggingProperties</a>: <i><a href="loggingproperties.md">LoggingProperties</a></i>
     <a href="#endpoint" title="Endpoint">Endpoint</a>: <i><a href="endpoint.md">Endpoint</a></i>
@@ -407,6 +409,14 @@ _Type_: String
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
+#### Id
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
 #### OwnerAccount
 
 _Required_: No
@@ -657,10 +667,6 @@ When you pass the logical ID of this resource to the intrinsic `Ref` function, R
 The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
 
 For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
-
-#### Id
-
-Returns the <code>Id</code> value.
 
 #### DeferMaintenanceIdentifier
 

--- a/aws-redshift-cluster/pom.xml
+++ b/aws-redshift-cluster/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>redshift</artifactId>
-            <version>2.21.13</version>
+            <version>2.21.37</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
 

--- a/aws-redshift-cluster/resource-role.yaml
+++ b/aws-redshift-cluster/resource-role.yaml
@@ -30,6 +30,21 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "cloudwatch:PutMetricData"
+                - "ec2:AssociateAddress"
+                - "ec2:CreateNetworkInterface"
+                - "ec2:CreateVpcEndpoint"
+                - "ec2:DeleteNetworkInterface"
+                - "ec2:DeleteVpcEndpoints"
+                - "ec2:DescribeAddresses"
+                - "ec2:DescribeNetworkInterfaces"
+                - "ec2:DescribeSubnets"
+                - "ec2:DescribeVpcEndpoints"
+                - "ec2:DescribeVpcs"
+                - "ec2:DisassociateAddress"
+                - "ec2:ModifyNetworkInterfaceAttribute"
+                - "ec2:ModifyVpcEndpoint"
+                - "iam:CreateServiceLinkedRole"
                 - "redshift:CreateCluster"
                 - "redshift:CreateTags"
                 - "redshift:DeleteCluster"

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/CallbackContext.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/CallbackContext.java
@@ -7,6 +7,7 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
+    String namespaceArn = null;
     LoggingProperties loggingProperties;
     boolean callBackForReboot = false;
     boolean callBackForDelete = false;
@@ -19,6 +20,10 @@ public class CallbackContext extends StdCallbackContext {
     boolean callbackAfterClusterCreate = false;
     boolean callbackAfterClusterRestore = false;
     boolean callbackAfterAfterClusterParameterGroupNameModify = false;
+
+    public void setNamespaceArn(String namespaceArn) {this.namespaceArn = namespaceArn; }
+
+    public String getNamespaceArn() { return namespaceArn; }
 
     public void setLoggingProperties(LoggingProperties loggingProperties) {
         this.loggingProperties = loggingProperties;

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
@@ -73,26 +73,24 @@ public class ReadHandler extends BaseHandlerStd {
                     return progress;
                 })
                 .then(progress -> {
-                    progress = proxy.initiate("AWS-Redshift-Cluster::DescribeCluster", proxyClient, model, callbackContext)
+                    progress = proxy.initiate("AWS-Redshift-Cluster::DescribeCluster", proxyClient, progress.getResourceModel(), callbackContext)
                             .translateToServiceRequest(Translator::translateToDescribeClusterRequest)
                             .makeServiceCall(this::describeCluster)
                             .done((_request, _response, _client, _model, _context) -> {
-                                _model.setClusterNamespaceArn(Translator.translateFromReadResponse(_response).getClusterNamespaceArn());
                                 return ProgressEvent.progress(Translator.translateFromReadResponse(_response), callbackContext);
                             });
                     return  progress;
                 })
                 .then(progress -> {
-                    progress = proxy.initiate("AWS-Redshift-Cluster::GetResourcePolicy", proxyClient, model, callbackContext)
+                    logger.log("In Get");
+                    return proxy.initiate("AWS-Redshift-ResourcePolicy::Get", proxyClient, progress.getResourceModel(), callbackContext)
                             .translateToServiceRequest(Translator::translateToGetResourcePolicy)
                             .makeServiceCall(this::getNamespaceResourcePolicy)
                             .done((_request, _response, _client, _model, _context) -> {
-                                _model.setNamespaceResourcePolicy(Translator.translateFromGetResourcePolicy(_response, logger).getNamespaceResourcePolicy());
-                                return ProgressEvent.progress(_model, callbackContext);
+                                _model.setNamespaceResourcePolicy(Translator.convertStringToJson(_response.resourcePolicy().policy(), logger));
+                                _model.setLoggingProperties(callbackContext.getLoggingProperties());
+                                return ProgressEvent.defaultSuccessHandler(_model);
                             });
-                    progress.getResourceModel().setLoggingProperties(callbackContext.getLoggingProperties());
-                    progress.getResourceModel().setNamespaceResourcePolicy(model.getNamespaceResourcePolicy());
-                    return ProgressEvent.defaultSuccessHandler(model);
                 });
     }
 

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/Translator.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/Translator.java
@@ -906,9 +906,9 @@ public class Translator {
    * @param model resource model
    * @return putResourcePolicyRequest the service request to put a policy on resource
    */
-  static PutResourcePolicyRequest translateToPutResourcePolicy(final ResourceModel model, Logger logger) {
+  static PutResourcePolicyRequest translateToPutResourcePolicy(final ResourceModel model, final String namespaceArn, Logger logger) {
     return PutResourcePolicyRequest.builder()
-            .resourceArn(model.getClusterNamespaceArn())
+            .resourceArn(namespaceArn)
             .policy(convertJsonToString(model.getNamespaceResourcePolicy(), logger))
             .build();
   }
@@ -916,13 +916,6 @@ public class Translator {
   static GetResourcePolicyRequest translateToGetResourcePolicy(final ResourceModel model) {
     return GetResourcePolicyRequest.builder()
             .resourceArn(model.getClusterNamespaceArn())
-            .build();
-  }
-
-  static ResourceModel translateFromGetResourcePolicy(final GetResourcePolicyResponse awsResponse, Logger logger) {
-    return ResourceModel.builder()
-            .clusterNamespaceArn(awsResponse.resourcePolicy().resourceArn())
-            .namespaceResourcePolicy(convertStringToJson(awsResponse.resourcePolicy().policy(), logger))
             .build();
   }
 

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/UpdateHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/UpdateHandler.java
@@ -268,7 +268,7 @@ public class UpdateHandler extends BaseHandlerStd {
                         }
                         else {
                             return proxy.initiate("AWS-Redshift-Cluster::PutNamespaceResourcePolicy", proxyClient, model, callbackContext)
-                                    .translateToServiceRequest(resourceModel -> Translator.translateToPutResourcePolicy(resourceModel, logger))
+                                    .translateToServiceRequest(resourceModel -> Translator.translateToPutResourcePolicy(resourceModel, model.getClusterNamespaceArn(), logger))
                                     .makeServiceCall(this::putNamespaceResourcePolicy)
                                     .progress();
                         }

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/CreateHandlerTest.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/CreateHandlerTest.java
@@ -270,7 +270,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         ResourceModel responseModel = createClusterResponseModel();
         responseModel.setLoggingProperties(LOGGING_PROPERTIES_DISABLED);
         responseModel.setNamespaceResourcePolicy(Translator.convertStringToJson(NAMESPACE_POLICY, logger));
-        responseModel.setMasterUserPassword(MASTER_USERPASSWORD);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(requestModel)

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/UpdateHandlerTest.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/UpdateHandlerTest.java
@@ -98,7 +98,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         previousModel.setNamespaceResourcePolicy(Translator.convertStringToJson(NAMESPACE_POLICY, logger));
 
         ResourceModel updateModel = createClusterResponseModel();
-        updateModel.setNamespaceResourcePolicy(Translator.convertStringToJson(NAMESPACE_POLICY_EMPTY, logger));
+        updateModel.setNamespaceResourcePolicy(null);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(updateModel)
@@ -111,7 +111,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().describeClusters(any(DescribeClustersRequest.class))).thenReturn(describeClustersResponseSdk());
         when(proxyClient.client().describeLoggingStatus(any(DescribeLoggingStatusRequest.class))).thenReturn(describeLoggingStatusFalseResponseSdk());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
-        when(proxyClient.client().deleteResourcePolicy(any(DeleteResourcePolicyRequest.class))).thenReturn(null);
 
         ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 

--- a/aws-redshift-cluster/template.yml
+++ b/aws-redshift-cluster/template.yml
@@ -5,7 +5,7 @@ Description: AWS SAM template for the AWS::Redshift::Cluster resource type
 Globals:
   Function:
     Timeout: 180  # docker start-up times can be long for SAM CLI
-    MemorySize: 256
+    MemorySize: 2024
 
 Resources:
   TypeFunction:


### PR DESCRIPTION
1. Remove describeCluster call from CreateHandler.
2. Code Refactor wrt ResourcePolicy API changes.
3. Remove Id property from schema readonly properties.
4. Update redshift awssdk and projectlombok versions.
5. Add EC2 permission for the Cfn Iam role to create instance and manage them.
6. Add CloudWatch putmetrics permission to write logs to CloudFormation.
7. Increase MemorySize in template.yml file.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
