### PR TITLE
Add stack tag support to cluster-parameter-group resource

### DIFF
--- a/aws-redshift-clusterparametergroup/src/test/java/software/amazon/redshift/clusterparametergroup/TestUtils.java
+++ b/aws-redshift-clusterparametergroup/src/test/java/software/amazon/redshift/clusterparametergroup/TestUtils.java
@@ -25,6 +25,8 @@ public class TestUtils {
 
     final static List<Tag> TAGS = Arrays.asList(new Tag("key1", "val1"), new Tag("key2", "val2"), new Tag("key3", "val3"));
 
+    final static Map<String, String> PREVIOUS_TAGS = ImmutableMap.of("key4", "val4", "key2", "val2");
+
     final static List<software.amazon.awssdk.services.redshift.model.Tag> SDK_TAGS = Arrays.asList(
             software.amazon.awssdk.services.redshift.model.Tag.builder().key("key1").value("val1").build(),
             software.amazon.awssdk.services.redshift.model.Tag.builder().key("key2").value("val2").build(),

--- a/aws-redshift-clusterparametergroup/src/test/java/software/amazon/redshift/clusterparametergroup/UpdateHandlerTest.java
+++ b/aws-redshift-clusterparametergroup/src/test/java/software/amazon/redshift/clusterparametergroup/UpdateHandlerTest.java
@@ -51,6 +51,7 @@ import static software.amazon.redshift.clusterparametergroup.TestUtils.DESIRED_R
 import static software.amazon.redshift.clusterparametergroup.TestUtils.PARAMETER_GROUP_FAMILY;
 import static software.amazon.redshift.clusterparametergroup.TestUtils.PARAMETER_GROUP_NAME;
 import static software.amazon.redshift.clusterparametergroup.TestUtils.PREVIOUS_PARAMETERS;
+import static software.amazon.redshift.clusterparametergroup.TestUtils.PREVIOUS_TAGS;
 import static software.amazon.redshift.clusterparametergroup.TestUtils.TAGS;
 import static software.amazon.redshift.clusterparametergroup.TestUtils.WLM_JSON_CONFIGURATION;
 import static software.amazon.redshift.clusterparametergroup.TestUtils.getSdkParametersFromParameters;
@@ -82,6 +83,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .desiredResourceState(COMPLETE_MODEL)
                 .desiredResourceTags(DESIRED_RESOURCE_TAGS)
                 .region(AWS_REGION)
+                .previousResourceTags(PREVIOUS_TAGS)
                 .build();
 
         when(proxyClient.client().modifyClusterParameterGroup(any(ModifyClusterParameterGroupRequest.class)))


### PR DESCRIPTION
The create-parameter-group and modify tags can be tagged with only resource-level tags as of now, stack level tags are not added as the part of this process to the resource.
    Stack Level Tags: are tags specified in the AWS console, they should be shared by all resources created inside that stack.
    Resource Level Tags: are tags specified in CloudFormation templates.
    This commit provides support to add stack level tags to the resources
