### PR TITLE
Resource policy exception

### DIFF
--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
@@ -169,6 +169,9 @@ public class ReadHandler extends BaseHandlerStd {
         } catch (InvalidPolicyException | UnsupportedOperationException e) {
             throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
         } catch (RedshiftException e) {
+            /* This error handling is required for backward compatibility. Since ResourcePolicy APIs
+            are new and might not be updated in the roles that create Clusters. Instead of throwing an
+            exception, we need to catch this and log the error, and continue with create cluster.*/
             if (e.awsErrorDetails().errorCode().equals(GET_RESOURCE_POLICY_ERROR_CODE) &&
                     e.awsErrorDetails().errorMessage().contains(GET_RESOURCE_POLICY_ERROR)) {
                 logger.log(String.format("RedshiftException: User is not authorized to perform: redshift:GetResourcePolicy on resource %s",

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
@@ -171,7 +171,10 @@ public class ReadHandler extends BaseHandlerStd {
         } catch (RedshiftException e) {
             /* This error handling is required for backward compatibility. Since ResourcePolicy APIs
             are new and might not be updated in the roles that create Clusters. Instead of throwing an
-            exception, we need to catch this and log the error, and continue with create cluster.*/
+            exception, we need to catch this and log the error, and continue with create cluster.
+            For new customers who want to use ResourcePolicy APIs, they first have to first CreateCluster
+            with NamespaceResourcePolicy property which needs both PutResourcePolicy and GetResourcePolicy
+            permissions, it's rare to hit this exception while creating cluster with namespace resource policy*/
             if (e.awsErrorDetails().errorCode().equals(GET_RESOURCE_POLICY_ERROR_CODE) &&
                     e.awsErrorDetails().errorMessage().contains(GET_RESOURCE_POLICY_ERROR)) {
                 logger.log(String.format("RedshiftException: User is not authorized to perform: redshift:GetResourcePolicy on resource %s",

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
@@ -38,7 +38,6 @@ public class ReadHandler extends BaseHandlerStd {
     private final String GET_RESOURCE_POLICY_ERROR = "not authorized to perform: redshift:GetResourcePolicy";
     private final String GET_RESOURCE_POLICY_ERROR_CODE = "403";
 
-
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
         final ResourceHandlerRequest<ResourceModel> request,


### PR DESCRIPTION
Handle GetResourcePolicy exception in case of not authorized error. This is required for backward compatibility and not to cause errors while creating Clusters with existing permissions set. Also removed unused code in Read Handler.

Exceptions will be thrown if `NamespaceResourcePolicy` is set on cfn template but `redshift:GetResourcePolicy` permissions are not included in the roles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
