### PR TITLE
No-Op method for handling GetResourcePolicy exceptions.

### DIFF
--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/CreateHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/CreateHandler.java
@@ -246,8 +246,7 @@ public class CreateHandler extends BaseHandlerStd {
             PutResourcePolicyResponse putResponse = null;
 
         try {
-            logger.log(String.format("%s %s putResourcePolicy.", ResourceModel.TYPE_NAME,
-                    putRequest.resourceArn()));
+            logger.log(String.format("PutResourcePolicy for Cluster Namespace %s", putRequest.resourceArn()));
             putResponse = proxyClient.injectCredentialsAndInvokeV2(putRequest, proxyClient.client()::putResourcePolicy);
         } catch (ResourceNotFoundException e){
             throw new CfnNotFoundException(e);

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/Translator.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/Translator.java
@@ -963,7 +963,11 @@ public class Translator {
     };
     try {
       if (policy != null) {
-        json = mapper.readValue(URLDecoder.decode(policy, StandardCharsets.UTF_8.toString()), typeRef);
+          if (policy.isEmpty()) {
+              logger.log("Empty NamespaceResourcePolicy");
+          } else {
+              json = mapper.readValue(URLDecoder.decode(policy, StandardCharsets.UTF_8.toString()), typeRef);
+        }
       }
     } catch (IOException e) {
       logger.log("Error parsing Policy String to Json");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Read Handler - NoOp method for handling `GetresourcePolicy` Exceptions - this method will assign empty value to `NamespaceResourcePolicy` if there are permission issues that restrict accessing GetResourcePolicy API. Also, empty value is assigned if NamespaceResourcePolicy is not found on the Cluster. Assigning empty value will suppress NamespaceResourcePolicy propery in  `CreateCluster` Cfn response.
2. Translator - Update logger to handle empty NamespaceResourcePolicy.
3. Create Handler - Minor logger change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
