### PR TITLE
Cloudformation support for Secrets Manager Integration

### DIFF
--- a/aws-redshift-cluster/aws-redshift-cluster.json
+++ b/aws-redshift-cluster/aws-redshift-cluster.json
@@ -67,7 +67,7 @@
             "maxLength": 128
         },
         "MasterUserPassword": {
-            "description": "The password associated with the master user account for the cluster that is being created. Password must be between 8 and 64 characters in length, should have at least one uppercase letter.Must contain at least one lowercase letter.Must contain one number.Can be any printable ASCII character.",
+            "description": "The password associated with the master user account for the cluster that is being created. You can't use MasterUserPassword if ManageMasterPassword is true. Password must be between 8 and 64 characters in length, should have at least one uppercase letter.Must contain at least one lowercase letter.Must contain one number.Can be any printable ASCII character.",
             "type": "string",
             "maxLength": 64
         },
@@ -281,6 +281,18 @@
         "NamespaceResourcePolicy": {
             "description": "The namespace resource policy document that will be attached to a Redshift cluster.",
             "type": "object"
+        },
+        "ManageMasterPassword": {
+            "description": "A boolean indicating if the redshift cluster's admin user credentials is managed by Redshift or not. You can't use MasterUserPassword if ManageMasterPassword is true. If ManageMasterPassword is false or not set, Amazon Redshift uses MasterUserPassword for the admin user account's password.",
+            "type": "boolean"
+        },
+        "MasterPasswordSecretKmsKeyId": {
+            "description": "The ID of the Key Management Service (KMS) key used to encrypt and store the cluster's admin user credentials secret.",
+            "type": "string"
+        },
+        "MasterPasswordSecretArn": {
+            "description": "The Amazon Resource Name (ARN) for the cluster's admin user credentials secret.",
+            "type": "string"
         }
     },
     "additionalProperties": false,
@@ -297,7 +309,8 @@
         "/properties/DeferMaintenanceIdentifier",
         "/properties/Endpoint/Port",
         "/properties/Endpoint/Address",
-        "/properties/ClusterNamespaceArn"
+        "/properties/ClusterNamespaceArn",
+        "/properties/MasterPasswordSecretArn"
     ],
     "createOnlyProperties": [
         "/properties/ClusterIdentifier",
@@ -313,7 +326,8 @@
         "/properties/Classic",
         "/properties/SnapshotIdentifier",
         "/properties/DeferMaintenance",
-        "/properties/DeferMaintenanceDuration"
+        "/properties/DeferMaintenanceDuration",
+        "/properties/ManageMasterPassword"
     ],
     "tagging": {
         "taggable": true

--- a/aws-redshift-cluster/docs/README.md
+++ b/aws-redshift-cluster/docs/README.md
@@ -61,7 +61,9 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#resourceaction" title="ResourceAction">ResourceAction</a>" : <i>String</i>,
         "<a href="#rotateencryptionkey" title="RotateEncryptionKey">RotateEncryptionKey</a>" : <i>Boolean</i>,
         "<a href="#multiaz" title="MultiAZ">MultiAZ</a>" : <i>Boolean</i>,
-        "<a href="#namespaceresourcepolicy" title="NamespaceResourcePolicy">NamespaceResourcePolicy</a>" : <i>Map</i>
+        "<a href="#namespaceresourcepolicy" title="NamespaceResourcePolicy">NamespaceResourcePolicy</a>" : <i>Map</i>,
+        "<a href="#managemasterpassword" title="ManageMasterPassword">ManageMasterPassword</a>" : <i>Boolean</i>,
+        "<a href="#masterpasswordsecretkmskeyid" title="MasterPasswordSecretKmsKeyId">MasterPasswordSecretKmsKeyId</a>" : <i>String</i>,
     }
 }
 </pre>
@@ -125,6 +127,8 @@ Properties:
     <a href="#rotateencryptionkey" title="RotateEncryptionKey">RotateEncryptionKey</a>: <i>Boolean</i>
     <a href="#multiaz" title="MultiAZ">MultiAZ</a>: <i>Boolean</i>
     <a href="#namespaceresourcepolicy" title="NamespaceResourcePolicy">NamespaceResourcePolicy</a>: <i>Map</i>
+    <a href="#managemasterpassword" title="ManageMasterPassword">ManageMasterPassword</a>: <i>Boolean</i>
+    <a href="#masterpasswordsecretkmskeyid" title="MasterPasswordSecretKmsKeyId">MasterPasswordSecretKmsKeyId</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -155,7 +159,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### MasterUserPassword
 
-The password associated with the master user account for the cluster that is being created. Password must be between 8 and 64 characters in length, should have at least one uppercase letter.Must contain at least one lowercase letter.Must contain one number.Can be any printable ASCII character.
+The password associated with the master user account for the cluster that is being created. You can't use MasterUserPassword if ManageMasterPassword is true. Password must be between 8 and 64 characters in length, should have at least one uppercase letter.Must contain at least one lowercase letter.Must contain one number.Can be any printable ASCII character.
 
 _Required_: No
 
@@ -646,6 +650,26 @@ _Type_: Map
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+#### ManageMasterPassword
+
+A boolean indicating if the redshift cluster's admin user credentials is managed by Redshift or not. You can't use MasterUserPassword if ManageMasterPassword is true. If ManageMasterPassword is false or not set, Amazon Redshift uses MasterUserPassword for the admin user account's password.
+
+_Required_: No
+
+_Type_: Boolean
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MasterPasswordSecretKmsKeyId
+
+The ID of the Key Management Service (KMS) key used to encrypt and store the cluster's admin user credentials secret.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
 ## Return Values
 
 ### Ref
@@ -673,3 +697,7 @@ Returns the <code>Address</code> value.
 #### ClusterNamespaceArn
 
 The Amazon Resource Name (ARN) of the cluster namespace.
+
+#### MasterPasswordSecretArn
+
+The Amazon Resource Name (ARN) for the cluster's admin user credentials secret.

--- a/aws-redshift-cluster/pom.xml
+++ b/aws-redshift-cluster/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>redshift</artifactId>
-            <version>2.21.37</version>
+            <version>2.21.44</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/BaseHandlerStd.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/BaseHandlerStd.java
@@ -207,7 +207,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
   // check for required parameters to not have null values
   protected boolean invalidCreateClusterRequest(ResourceModel model) {
     return model.getClusterIdentifier() == null || model.getNodeType() == null
-            || model.getMasterUsername() == null || model.getMasterUserPassword() == null;
+            || model.getMasterUsername() == null;
   }
 
   protected boolean issueModifyClusterParameterGroupRequest(ResourceModel prevModel, ResourceModel model) {

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/Translator.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/Translator.java
@@ -114,6 +114,8 @@ public class Translator {
             .enhancedVpcRouting(model.getEnhancedVpcRouting())
             .maintenanceTrackName(model.getMaintenanceTrackName())
             .multiAZ(model.getMultiAZ())
+            .manageMasterPassword(model.getManageMasterPassword())
+            .masterPasswordSecretKmsKeyId(model.getMasterPasswordSecretKmsKeyId())
             .build();
   }
 
@@ -593,6 +595,17 @@ public class Translator {
             .findAny()
             .orElse(null);
 
+    final String masterPasswordSecretArn = streamOfOrEmpty(awsResponse.clusters())
+            .map(software.amazon.awssdk.services.redshift.model.Cluster::masterPasswordSecretArn)
+            .filter(Objects::nonNull)
+            .findAny()
+            .orElse(null);
+
+    final String masterPasswordSecretKmsKeyId = streamOfOrEmpty(awsResponse.clusters())
+            .map(software.amazon.awssdk.services.redshift.model.Cluster::masterPasswordSecretKmsKeyId)
+            .filter(Objects::nonNull)
+            .findAny()
+            .orElse(null);
 
     return ResourceModel.builder()
             .clusterIdentifier(clusterIdentifier)
@@ -634,6 +647,8 @@ public class Translator {
             .deferMaintenanceIdentifier(translateDeferMaintenanceIdentifierFromSdk(deferMaintenanceWindows))
             .deferMaintenanceStartTime(translateDeferMaintenanceStartTimeFromSdk(deferMaintenanceWindows))
             .deferMaintenanceEndTime(translateDeferMaintenanceEndTimeFromSdk(deferMaintenanceWindows))
+            .masterPasswordSecretArn(masterPasswordSecretArn)
+            .masterPasswordSecretKmsKeyId(masterPasswordSecretKmsKeyId)
             .build();
   }
 
@@ -683,7 +698,7 @@ public class Translator {
   static ModifyClusterRequest translateToUpdateRequest(final ResourceModel model, final ResourceModel prevModel) {
     ModifyClusterRequest modifyClusterRequest =  ModifyClusterRequest.builder()
             .clusterIdentifier(model.getClusterIdentifier())
-            .masterUserPassword(model.getMasterUserPassword().equals(prevModel.getMasterUserPassword()) ? null : model.getMasterUserPassword())
+            .masterUserPassword(model.getMasterUserPassword() == null || model.getMasterUserPassword().equals(prevModel.getMasterUserPassword()) ? null : model.getMasterUserPassword())
             .allowVersionUpgrade(model.getAllowVersionUpgrade() == null || model.getAllowVersionUpgrade().equals(prevModel.getAllowVersionUpgrade()) ? null : model.getAllowVersionUpgrade())
             .automatedSnapshotRetentionPeriod(model.getAutomatedSnapshotRetentionPeriod() == null || model.getAutomatedSnapshotRetentionPeriod().equals(prevModel.getAutomatedSnapshotRetentionPeriod()) ? null : model.getAutomatedSnapshotRetentionPeriod())
             //.clusterParameterGroupName(model.getClusterParameterGroupName() == null || model.getClusterParameterGroupName().equals(prevModel.getClusterParameterGroupName()) ? null : model.getClusterParameterGroupName())
@@ -706,6 +721,8 @@ public class Translator {
             .maintenanceTrackName(model.getMaintenanceTrackName() == null || model.getMaintenanceTrackName().equals(prevModel.getMaintenanceTrackName()) ? null : model.getMaintenanceTrackName())
             .enhancedVpcRouting(model.getEnhancedVpcRouting() == null || model.getEnhancedVpcRouting().equals(prevModel.getEnhancedVpcRouting()) ? null : model.getEnhancedVpcRouting())
             .multiAZ(model.getMultiAZ() == null || model.getMultiAZ().equals(prevModel.getMultiAZ()) ? null : model.getMultiAZ())
+            .manageMasterPassword(model.getManageMasterPassword())
+            .masterPasswordSecretKmsKeyId(model.getMasterPasswordSecretKmsKeyId() == null || model.getMasterPasswordSecretKmsKeyId().equals(prevModel.getMasterPasswordSecretKmsKeyId()) ? null : model.getMasterPasswordSecretKmsKeyId())
             .build();
 
     return modifyClusterRequest;
@@ -877,6 +894,8 @@ public class Translator {
             .numberOfNodes(model.getNumberOfNodes())
             .encrypted(model.getEncrypted())
             .multiAZ(model.getMultiAZ())
+            .manageMasterPassword(model.getManageMasterPassword())
+            .masterPasswordSecretKmsKeyId(model.getMasterPasswordSecretKmsKeyId())
             .build();
   }
 

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/UpdateHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/UpdateHandler.java
@@ -137,7 +137,9 @@ public class UpdateHandler extends BaseHandlerStd {
             "PreferredMaintenanceWindow",
             "PubliclyAccessible",
             "VpcSecurityGroupIds",
-            "MultiAZ"
+            "MultiAZ",
+            "ManageMasterPassword",
+            "MasterPasswordSecretKmsKeyId"
     };
     public static final String[] DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_SENSITIVE = new String[] {
             "MasterUserPassword"

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/AbstractTestBase.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/AbstractTestBase.java
@@ -24,6 +24,7 @@ public class AbstractTestBase {
   protected static final String AWS_PARTITION;
   protected static final String AWS_ACCOUNT_ID;
   protected static final String CLUSTER_IDENTIFIER;
+  protected static final String SNAPSHOT_IDENTIFIER;
   protected static final String CLUSTER_NAMESPACE_UUID;
   protected static final String MASTER_USERNAME;
   protected static final String MASTER_USERPASSWORD;
@@ -65,6 +66,7 @@ public class AbstractTestBase {
     DEFER_MAINTENANCE_IDENTIFIER = "cfn-defer-maintenance-identifier";
     DEFER_MAINTENANCE_START_TIME = "2023-12-10T00:00:00Z";
     DEFER_MAINTENANCE_END_TIME = "2024-01-19T00:00:00Z";
+    SNAPSHOT_IDENTIFIER = "redshift-cluster-1-snapshot";
 
     RESOURCE_POLICY = ResourcePolicy.builder()
             .resourceArn(CLUSTER_NAMESPACE_ARN)
@@ -178,6 +180,12 @@ public class AbstractTestBase {
             .iamRoles(Collections.emptyList())
             .vpcSecurityGroupIds(Collections.emptyList())
             .tags(Collections.emptyList())
+            .build();
+  }
+
+  public static ResourceModel restoreClusterRequestModel() {
+    return createClusterRequestModel().toBuilder()
+            .snapshotIdentifier(SNAPSHOT_IDENTIFIER)
             .build();
   }
 

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/TestUtils.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/TestUtils.java
@@ -25,6 +25,8 @@ public class TestUtils {
     final static String OWNER_ACCOUNT_NO = "1111";
     final static String MULTIAZ_ENABLED = "Enabled";
     final static String MULTIAZ_DISABLED = "Disabled";
+    final static String MASTER_PASSWORD_SECRET_KMS_KEY_ID = "master-password-secret-kms-key-id";
+    final static String MASTER_PASSWORD_SECRET_ARN = "secret-arn";
 
     final static Cluster BASIC_CLUSTER = Cluster.builder()
             .clusterStatus("available")
@@ -61,6 +63,26 @@ public class TestUtils {
             .clusterSecurityGroups(Collections.emptyList())
             .iamRoles(Collections.emptyList())
             .vpcSecurityGroups(Collections.emptyList())
+            .build();
+
+    final static Cluster MANAGED_ADMIN_PASSWORD_CLUSTER = Cluster.builder()
+            .clusterStatus("available")
+            .clusterAvailabilityStatus("Available")
+            .clusterIdentifier(CLUSTER_IDENTIFIER)
+            .masterUsername(MASTER_USERNAME)
+            .nodeType(NODETYPE)
+            .numberOfNodes(NUMBER_OF_NODES)
+            .allowVersionUpgrade(true)
+            .automatedSnapshotRetentionPeriod(0)
+            .encrypted(false)
+            .enhancedVpcRouting(false)
+            .manualSnapshotRetentionPeriod(1)
+            .publiclyAccessible(false)
+            .clusterSecurityGroups(Collections.emptyList())
+            .iamRoles(Collections.emptyList())
+            .vpcSecurityGroups(Collections.emptyList())
+            .masterPasswordSecretArn(MASTER_PASSWORD_SECRET_ARN)
+            .masterPasswordSecretKmsKeyId(MASTER_PASSWORD_SECRET_KMS_KEY_ID)
             .build();
 
     final static Cluster BASIC_CLUSTER_READ = Cluster.builder()

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/UpdateHandlerTest.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/UpdateHandlerTest.java
@@ -486,10 +486,10 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         // todo: make tests more independent so we can add tests like this elsewhere
         verify(handler).sleep(10);
-        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_SENSITIVE.length == 1);
-        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_INSENSITIVE.length == 17);
+        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_SENSITIVE.length).isEqualTo(1);
+        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_INSENSITIVE.length).isEqualTo(21);
 
-        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_SENSITIVE[0].equals("MasterUserPassword"));
+        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_SENSITIVE[0]).isEqualTo("MasterUserPassword");
 
         List<String> insensitiveFileds = Arrays.asList(
                 "AllowVersionUpgrade",
@@ -513,9 +513,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         );
 
         for (int i = 0; i < insensitiveFileds.size(); i++) {
-            assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_INSENSITIVE[i].equals(
-                    insensitiveFileds.get(i)
-            ));
+            assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_INSENSITIVE[i]).isEqualTo(
+                    insensitiveFileds.get(i));
         }
     }
 
@@ -568,11 +567,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         // todo: make tests more independent so we can add tests like this elsewhere
         verify(handler).sleep(10);
-        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_SENSITIVE.length == 1);
-        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_INSENSITIVE.length == 18);
-
-        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_SENSITIVE[0].equals("Encrypted"));
-        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_SENSITIVE[0].equals("MultiAZ"));
+        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_SENSITIVE.length).isEqualTo(1);
+        assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_INSENSITIVE.length).isEqualTo(21);
 
         List<String> insensitiveFileds = Arrays.asList(
                 "AllowVersionUpgrade",
@@ -597,9 +593,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
         );
 
         for (int i = 0; i < insensitiveFileds.size(); i++) {
-            assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_INSENSITIVE[i].equals(
+            assertThat(UpdateHandler.DETECTABLE_MODIFY_CLUSTER_ATTRIBUTES_INSENSITIVE[i]).isEqualTo(
                     insensitiveFileds.get(i)
-            ));
+            );
         }
     }
 


### PR DESCRIPTION
The changes provide Cloudformation support for Secrets Manager integration with Redshift clusters. With this new feature, customers can opt in to store their cluster's admin credentials in a service linked secret in Secrets Manager. It allows us to create/modify/restore Redshift clusters with Secrets Manager support using the Cloudformation template. The changes in this request allow us to use create-cluster, modify-cluster, restore-from-cluster-snapshot APIs for Redshift clusters when opting in to this feature.

We are adding a new boolean parameter "ManageMasterPassword" to allow customers to opt in to this feature and another parameter "MasterPasswordSecretKmsKeyId" allows customers to specify the key ID of the KMS key in the customer account which will be used to encrypt the cluster secret. These parameters can be used while setting CreateClusterRequest, ModifyClusterRequest and RestoreFromClusterSnapshotRequest. The response of these requests will return the "MasterPasswordSecretArn" when the cluster is opted in to this feature. 