### PR TITLE
Fix CTv2 Contract tests

### DIFF
--- a/aws-redshift-endpointaccess/aws-redshift-endpointaccess.json
+++ b/aws-redshift-endpointaccess/aws-redshift-endpointaccess.json
@@ -159,6 +159,7 @@
                 "redshift:CreateEndpointAccess",
                 "redshift:DescribeEndpointAccess",
                 "ec2:CreateClientVpnEndpoint",
+                "ec2:CreateVpcEndpoint",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeAddresses",
@@ -171,6 +172,7 @@
             "permissions": [
                 "redshift:DescribeEndpointAccess",
                 "ec2:DescribeClientVpnEndpoints",
+                "ec2:DescribeVpcEndpoint",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeAddresses",
@@ -183,6 +185,7 @@
                 "redshift:DescribeEndpointAccess",
                 "redshift:ModifyEndpointAccess",
                 "ec2:ModifyClientVpnEndpoint",
+                "ec2:ModifyVpcEndpoint",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeAddresses",
@@ -196,11 +199,13 @@
                 "redshift:DeleteEndpointAccess",
                 "redshift:DescribeEndpointAccess",
                 "ec2:DeleteClientVpnEndpoint",
+                "ec2:DeleteVpcEndpoint",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeAddresses",
                 "ec2:DescribeInternetGateways",
-                "ec2:DescribeSubnets"
+                "ec2:DescribeSubnets",
+                "ec2:DescribeVpcEndpoint"
             ],
             "timeoutInMinutes": 60
         },
@@ -208,6 +213,7 @@
             "permissions": [
                 "redshift:DescribeEndpointAccess",
                 "ec2:DescribeClientVpnEndpoints",
+                "ec2:DescribeVpcEndpoints",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeAddresses",


### PR DESCRIPTION
CTV2 contract tests were failing for Endpoint access because of missing EC2 permissions. Ran ctv2 tests locally for endpoint access following this guide. Contract tests passed locally


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
