### PR TITLE
Handle Unsupported ResourcePolicy Exceptions.

### DIFF
--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
@@ -171,7 +171,8 @@ public class ReadHandler extends BaseHandlerStd {
             logger.log(String.format("NamespaceResourcePolicy not found for namespace %s", awsRequest.resourceArn()));
             return noOpNamespaceResourcePoliy(awsRequest);
         } catch (InvalidPolicyException | UnsupportedOperationException e) {
-            // ResourcePolicy is not enabled in all regions.
+            /* ResourcePolicy is not enabled in all regions, we should handle unsupported operation exception
+            if NamespaceResourcePolicy is not added as a property while creating Cluster resource. */
             if(!containsResourcePolicy && e.statusCode() == RESOURCE_POLICY_UNSUPPORTED_ERR_STATUS_CODE &&
                     e.awsErrorDetails().errorMessage().contains(RESOURCE_POLICY_UNSUPPORTED_ERROR)) {
                 logger.log(e.getMessage());

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.redshift.model.InvalidTagException;
 import software.amazon.awssdk.services.redshift.model.RedshiftException;
 import software.amazon.awssdk.services.redshift.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.redshift.model.ResourcePolicy;
+import software.amazon.awssdk.services.redshift.model.UnsupportedOperationException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
@@ -29,14 +30,14 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.lang.UnsupportedOperationException;
-
 public class ReadHandler extends BaseHandlerStd {
     private Logger logger;
     private final String DESCRIBE_LOGGING_ERROR = "not authorized to perform: redshift:DescribeLoggingStatus";
     private final String DESCRIBE_LOGGING_ERROR_CODE = "403";
     private final String GET_RESOURCE_POLICY_ERROR = "not authorized to perform: redshift:GetResourcePolicy";
     private final Integer GET_RESOURCE_POLICY_ERR_STATUS_CODE = 403;
+    private final String RESOURCE_POLICY_UNSUPPORTED_ERROR = "The resource policy feature isn't supported";
+    private final Integer RESOURCE_POLICY_UNSUPPORTED_ERR_STATUS_CODE = 400;
     private boolean containsResourcePolicy = false;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -170,7 +171,14 @@ public class ReadHandler extends BaseHandlerStd {
             logger.log(String.format("NamespaceResourcePolicy not found for namespace %s", awsRequest.resourceArn()));
             return noOpNamespaceResourcePoliy(awsRequest);
         } catch (InvalidPolicyException | UnsupportedOperationException e) {
-            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+            // ResourcePolicy is not enabled in all regions.
+            if(!containsResourcePolicy && e.statusCode() == RESOURCE_POLICY_UNSUPPORTED_ERR_STATUS_CODE &&
+                    e.awsErrorDetails().errorMessage().contains(RESOURCE_POLICY_UNSUPPORTED_ERROR)) {
+                logger.log(e.getMessage());
+                return noOpNamespaceResourcePoliy(awsRequest);
+            } else {
+                throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+            }
         } catch (RedshiftException e) {
             /* This error handling is required for backward compatibility. Without this exception handling, existing customers creating
             or updating their clusters will see an error with permission issues - "is not authorized to perform: redshift:GetResourcePolicy",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ResourcePolicy API is not enabled in all the regions. We need to handle unsupported exceptions in regions where this API is not supported.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
