### PR TITLE
Changes related to JDK 17 runtime upgrade

### DIFF
--- a/aws-redshift-cluster/.rpdk-config
+++ b/aws-redshift-cluster/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Redshift::Cluster",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.redshift.cluster.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.redshift.cluster.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-redshift-cluster/template.yml
+++ b/aws-redshift-cluster/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.cluster.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-cluster-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.cluster.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-cluster-handler-1.0-SNAPSHOT.jar

--- a/aws-redshift-clusterparametergroup/.rpdk-config
+++ b/aws-redshift-clusterparametergroup/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Redshift::ClusterParameterGroup",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.redshift.clusterparametergroup.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.redshift.clusterparametergroup.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-redshift-clusterparametergroup/template.yml
+++ b/aws-redshift-clusterparametergroup/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.clusterparametergroup.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-clusterparametergroup-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.clusterparametergroup.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-clusterparametergroup-handler-1.0-SNAPSHOT.jar

--- a/aws-redshift-clustersubnetgroup/.rpdk-config
+++ b/aws-redshift-clustersubnetgroup/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Redshift::ClusterSubnetGroup",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.redshift.clustersubnetgroup.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.redshift.clustersubnetgroup.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-redshift-clustersubnetgroup/template.yml
+++ b/aws-redshift-clustersubnetgroup/template.yml
@@ -11,7 +11,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.clustersubnetgroup.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       MemorySize: 256
       CodeUri: ./target/aws-redshift-clustersubnetgroup-handler-1.0-SNAPSHOT.jar
 
@@ -19,6 +19,6 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.clustersubnetgroup.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       MemorySize: 256
       CodeUri: ./target/aws-redshift-clustersubnetgroup-handler-1.0-SNAPSHOT.jar

--- a/aws-redshift-endpointaccess/.rpdk-config
+++ b/aws-redshift-endpointaccess/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Redshift::EndpointAccess",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.redshift.endpointaccess.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.redshift.endpointaccess.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-redshift-endpointaccess/template.yml
+++ b/aws-redshift-endpointaccess/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.endpointaccess.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-endpointaccess-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.endpointaccess.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-endpointaccess-handler-1.0-SNAPSHOT.jar

--- a/aws-redshift-endpointauthorization/.rpdk-config
+++ b/aws-redshift-endpointauthorization/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Redshift::EndpointAuthorization",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.redshift.endpointauthorization.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.redshift.endpointauthorization.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-redshift-endpointauthorization/template.yml
+++ b/aws-redshift-endpointauthorization/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.endpointauthorization.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-endpointauthorization-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.endpointauthorization.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-endpointauthorization-handler-1.0-SNAPSHOT.jar

--- a/aws-redshift-eventsubscription/.rpdk-config
+++ b/aws-redshift-eventsubscription/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Redshift::EventSubscription",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.redshift.eventsubscription.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.redshift.eventsubscription.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-redshift-eventsubscription/template.yml
+++ b/aws-redshift-eventsubscription/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.eventsubscription.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-eventsubscription-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.eventsubscription.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-eventsubscription-handler-1.0-SNAPSHOT.jar

--- a/aws-redshift-scheduledaction/.rpdk-config
+++ b/aws-redshift-scheduledaction/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Redshift::ScheduledAction",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.redshift.scheduledaction.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.redshift.scheduledaction.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-redshift-scheduledaction/template.yml
+++ b/aws-redshift-scheduledaction/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.scheduledaction.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-scheduledaction-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.scheduledaction.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-redshift-scheduledaction-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
This CR contains changes related to JDK 17 runtime upgrade for all Redshift CFN resources. This change includes runtime upgrade in .rpdk-config and template.yml as per upgrade guidance.

Testing:
1. Run contract test for the resources after upgrade.
2. Verify CTV2 passes for each resource.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
