### PR TITLE
Update EventSubscription schema to allow upper case for SubscriptionName

### DIFF
--- a/aws-redshift-eventsubscription/aws-redshift-eventsubscription.json
+++ b/aws-redshift-eventsubscription/aws-redshift-eventsubscription.json
@@ -31,7 +31,7 @@
         "SubscriptionName": {
             "description": "The name of the Amazon Redshift event notification subscription",
             "type": "string",
-            "pattern": "^(?=^[a-z][a-z0-9]*(-[a-z0-9]+)*$).{1,255}$"
+            "pattern": "^(?=^[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*$).{1,255}$"
         },
         "SnsTopicArn": {
             "description": "The Amazon Resource Name (ARN) of the Amazon SNS topic used to transmit the event notifications.",

--- a/aws-redshift-eventsubscription/docs/README.md
+++ b/aws-redshift-eventsubscription/docs/README.md
@@ -52,7 +52,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Pattern_: <code>^(?=^[a-z][a-z0-9]*(-[a-z0-9]+)*$).{1,255}$</code>
+_Pattern_: <code>^(?=^[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*$).{1,255}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/aws-redshift-eventsubscription/overrides.json
+++ b/aws-redshift-eventsubscription/overrides.json
@@ -1,5 +1,6 @@
 {
     "CREATE": {
+        "/SubscriptionName": "redshift-event-subscription-contract-V2",
         "/SnsTopicArn": "{{RedshiftEventSubscriptionContractSns}}",
         "/SourceIds": [],
         "/Tags": [],


### PR DESCRIPTION
### Description

update the validation pattern for `SubscriptionName` property in `EventSubscription` schema to allow upper case characters.

### Testing and reproduction steps

```
Reproduced the current issue that upper case would fail SubscriptionName validation
1. modified overrides.json to add "/SubscriptionName": "redshift-event-subscription-contract-V2"
2. run contract test with cfn test -- -k contract_create_create
3. test failed

After updating SubscriptionName validation pattern
1. modified overrides.json to add "/SubscriptionName": "redshift-event-subscription-contract-V2"
2. run contract test with cfn test -- -k contract_create_create
3. test passed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
