### PR TITLE
Fix for allower uppercase in ScheduledActionName

### DIFF
--- a/aws-redshift-scheduledaction/aws-redshift-scheduledaction.json
+++ b/aws-redshift-scheduledaction/aws-redshift-scheduledaction.json
@@ -91,7 +91,7 @@
         "ScheduledActionName": {
             "description": "The name of the scheduled action. The name must be unique within an account.",
             "type": "string",
-            "pattern": "^(?=^[a-z][a-z0-9]*(-[a-z0-9]+)*$).{1,60}$"
+            "pattern": "^(?=^[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*$).{1,60}$"
         },
         "TargetAction": {
             "description": "A JSON format string of the Amazon Redshift API operation with input parameters.",

--- a/aws-redshift-scheduledaction/docs/README.md
+++ b/aws-redshift-scheduledaction/docs/README.md
@@ -49,7 +49,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Pattern_: <code>^(?=^[a-z][a-z0-9]*(-[a-z0-9]+)*$).{1,60}$</code>
+_Pattern_: <code>^(?=^[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*$).{1,60}$</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 


### PR DESCRIPTION
[Motivation]:
https://t.corp.amazon.com/P123773979/communication

[Description/Design]:
ScheduledAction pattern is different from service causing differences for customer between CLI and CFN. We are allowing the pattern to allow uppercase letter currently.

[Dependencies]:

[Testing]:
1. local handler invocation with uppercase scheduled action name succeeds.
2. CTV2 works with lower case letters only. API converts name to lower case. CTV2 expects the input and output name to be same
3. Deployed stack using cloudformation deploy with uppercase scheduled action name and it deploys successfully.

[Reviewers]:
Maintainer: userid
QA: userid

[Code Review]:

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
