### PR TITLE
Fix for ScheduledActionName inconsistency in CFN with CLI

### DIFF
--- a/aws-redshift-scheduledaction/aws-redshift-scheduledaction.json
+++ b/aws-redshift-scheduledaction/aws-redshift-scheduledaction.json
@@ -90,8 +90,7 @@
     "properties": {
         "ScheduledActionName": {
             "description": "The name of the scheduled action. The name must be unique within an account.",
-            "type": "string",
-            "pattern": "^(?=^[a-z][a-z0-9]*(-[a-z0-9]+)*$).{1,60}$"
+            "type": "string"
         },
         "TargetAction": {
             "description": "A JSON format string of the Amazon Redshift API operation with input parameters.",
@@ -107,8 +106,7 @@
         },
         "ScheduledActionDescription": {
             "description": "The description of the scheduled action.",
-            "type": "string",
-            "pattern": "^(?=^[\\x09\\x0a\\x0d\\x20-\\xff]*$).{1,255}$"
+            "type": "string"
         },
         "StartTime": {
             "description": "The start time in UTC of the scheduled action. Before this time, the scheduled action does not trigger.",

--- a/aws-redshift-scheduledaction/docs/README.md
+++ b/aws-redshift-scheduledaction/docs/README.md
@@ -49,8 +49,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Pattern_: <code>^(?=^[a-z][a-z0-9]*(-[a-z0-9]+)*$).{1,60}$</code>
-
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### TargetAction
@@ -88,8 +86,6 @@ The description of the scheduled action.
 _Required_: No
 
 _Type_: String
-
-_Pattern_: <code>^(?=^[\x09\x0a\x0d\x20-\xff]*$).{1,255}$</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
[Motivation]:
https://t.corp.amazon.com/P123773979/communication

[Description/Design]:
ScheduledAction pattern is different from service causing differences for customer between CLI and CFN. We are removing the pattern to keep it consistent with CLI

[Testing]:
1. local handler invocation with uppercase scheduled action name succeeds.
2. CTV2 works with lower case letters only. API converts name to lower case. CTV2 expects the input and output name to be same
3. Deployed stack using cloudformation deploy with uppercase scheduled action name and it deploys successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
