### PR TITLE
Updated Uluru Resource Relationship References for CFN Redshift Provisioned Resources

### DIFF
--- a/aws-redshift-cluster/aws-redshift-cluster.json
+++ b/aws-redshift-cluster/aws-redshift-cluster.json
@@ -31,7 +31,11 @@
             "additionalProperties": false,
             "properties": {
                 "BucketName": {
-                    "type": "string"
+                    "type": "string",
+                    "relationshipRef": {
+                        "typeName": "AWS::S3::Bucket",
+                        "propertyPath": "/properties/BucketName"
+                    }
                 },
                 "S3KeyPrefix": {
                     "type": "string"
@@ -90,7 +94,11 @@
         "ClusterParameterGroupName": {
             "description": "The name of the parameter group to be associated with this cluster.",
             "type": "string",
-            "maxLength": 255
+            "maxLength": 255,
+            "relationshipRef": {
+                "typeName": "AWS::Redshift::ClusterParameterGroup",
+                "propertyPath": "/properties/ParameterGroupName"
+            }
         },
         "ClusterType": {
             "description": "The type of the cluster. When cluster type is specified as single-node, the NumberOfNodes parameter is not required and if multi-node, the NumberOfNodes parameter is required",
@@ -102,7 +110,11 @@
         },
         "ClusterSubnetGroupName": {
             "description": "The name of a cluster subnet group to be associated with this cluster.",
-            "type": "string"
+            "type": "string",
+            "relationshipRef": {
+                "typeName": "AWS::Redshift::ClusterSubnetGroup",
+                "propertyPath": "/properties/ClusterSubnetGroupName"
+            }
         },
         "DBName": {
             "description": "The name of the first database to be created when the cluster is created. To create additional databases after the cluster is created, connect to the cluster with a SQL client and use SQL commands to create a database.",
@@ -110,7 +122,11 @@
         },
         "ElasticIp": {
             "description": "The Elastic IP (EIP) address for the cluster.",
-            "type": "string"
+            "type": "string",
+            "relationshipRef": {
+                "typeName": "AWS::EC2::EIP",
+                "propertyPath": "/properties/PublicIp"
+            }
         },
         "Encrypted": {
             "description": "If true, the data in the cluster is encrypted at rest.",
@@ -126,7 +142,18 @@
         },
         "KmsKeyId": {
             "description": "The AWS Key Management Service (KMS) key ID of the encryption key that you want to use to encrypt data in the cluster.",
-            "type": "string"
+            "type": "string",
+            "anyOf": [{
+                "relationshipRef": {
+                    "typeName": "AWS::KMS::Key",
+                    "propertyPath": "/properties/Arn"
+                }
+            }, {
+                "relationshipRef": {
+                    "typeName": "AWS::KMS::Key",
+                    "propertyPath": "/properties/KeyId"
+                }
+            }]
         },
         "NumberOfNodes": {
             "description": "The number of compute nodes in the cluster. This parameter is required when the ClusterType parameter is specified as multi-node.",
@@ -150,7 +177,18 @@
             "insertionOrder": false,
             "uniqueItems": false,
             "items": {
-                "type": "string"
+                "type": "string",
+                "anyOf": [{
+                    "relationshipRef": {
+                        "typeName": "AWS::EC2::SecurityGroup",
+                        "propertyPath": "/properties/Id"
+                    }
+                }, {
+                    "relationshipRef": {
+                        "typeName": "AWS::Redshift::ClusterSecurityGroup",
+                        "propertyPath": "/properties/Id"
+                    }
+                }]
             }
         },
         "IamRoles": {
@@ -159,7 +197,11 @@
             "insertionOrder": false,
             "maxItems": 50,
             "items": {
-                "type": "string"
+                "type": "string",
+                "relationshipRef": {
+                    "typeName": "AWS::IAM::Role",
+                    "propertyPath": "/properties/Arn"
+                }
             }
         },
         "Tags": {
@@ -178,7 +220,11 @@
             "insertionOrder": false,
             "uniqueItems": false,
             "items": {
-                "type": "string"
+                "type": "string",
+                "relationshipRef": {
+                    "typeName": "AWS::EC2::VPC",
+                    "propertyPath": "/properties/VpcId"
+                }
             }
         },
         "SnapshotClusterIdentifier": {
@@ -288,7 +334,18 @@
         },
         "MasterPasswordSecretKmsKeyId": {
             "description": "The ID of the Key Management Service (KMS) key used to encrypt and store the cluster's admin user credentials secret.",
-            "type": "string"
+            "type": "string",
+            "anyOf": [{
+                "relationshipRef": {
+                    "typeName": "AWS::KMS::Key",
+                    "propertyPath": "/properties/Arn"
+                }
+            }, {
+                "relationshipRef": {
+                    "typeName": "AWS::KMS::Key",
+                    "propertyPath": "/properties/KeyId"
+                }
+            }]
         },
         "MasterPasswordSecretArn": {
             "description": "The Amazon Resource Name (ARN) for the cluster's admin user credentials secret.",

--- a/aws-redshift-clustersubnetgroup/aws-redshift-clustersubnetgroup.json
+++ b/aws-redshift-clustersubnetgroup/aws-redshift-clustersubnetgroup.json
@@ -38,7 +38,11 @@
             "insertionOrder": false,
             "maxItems": 20,
             "items": {
-                "type": "string"
+                "type": "string",
+                "relationshipRef": {
+                    "typeName": "AWS::EC2::Subnet",
+                    "propertyPath": "/properties/SubnetId"
+                }
             }
         },
         "Tags": {

--- a/aws-redshift-endpointaccess/aws-redshift-endpointaccess.json
+++ b/aws-redshift-endpointaccess/aws-redshift-endpointaccess.json
@@ -9,7 +9,11 @@
             "properties": {
                 "VpcSecurityGroupId": {
                     "type": "string",
-                    "description": "The identifier of the VPC security group."
+                    "description": "The identifier of the VPC security group.",
+                    "relationshipRef": {
+                        "typeName": "AWS::EC2::SecurityGroup",
+                        "propertyPath": "/properties/Id"
+                    }
                 },
                 "Status": {
                     "type": "string",
@@ -24,15 +28,27 @@
             "properties": {
                 "NetworkInterfaceId": {
                     "type": "string",
-                    "description": "The network interface identifier."
+                    "description": "The network interface identifier.",
+                    "relationshipRef": {
+                        "typeName": "AWS::EC2::NetworkInterface",
+                        "propertyPath": "/properties/Id"
+                    }
                 },
                 "SubnetId": {
                     "type": "string",
-                    "description": "The subnet identifier."
+                    "description": "The subnet identifier.",
+                    "relationshipRef": {
+                        "typeName": "AWS::EC2::NetworkInterface",
+                        "propertyPath": "/properties/SubnetId"
+                    }
                 },
                 "PrivateIpAddress": {
                     "type": "string",
-                    "description": "The IPv4 address of the network interface within the subnet."
+                    "description": "The IPv4 address of the network interface within the subnet.",
+                    "relationshipRef": {
+                        "typeName": "AWS::EC2::NetworkInterface",
+                        "propertyPath": "/properties/PrivateIpAddress"
+                    }
                 },
                 "AvailabilityZone": {
                     "type": "string",
@@ -49,7 +65,11 @@
         },
         "ClusterIdentifier": {
             "description": "A unique identifier for the cluster. You use this identifier to refer to the cluster for any subsequent cluster operations such as deleting or modifying. All alphabetical characters must be lower case, no hypens at the end, no two consecutive hyphens. Cluster name should be unique for all clusters within an AWS account",
-            "type": "string"
+            "type": "string",
+            "relationshipRef": {
+                "typeName": "AWS::Redshift::Cluster",
+                "propertyPath": "/properties/ClusterIdentifier"
+            }
         },
         "VpcSecurityGroups": {
             "description": "A list of Virtual Private Cloud (VPC) security groups to be associated with the endpoint.",
@@ -80,7 +100,11 @@
         "SubnetGroupName": {
             "description": "The subnet group name where Amazon Redshift chooses to deploy the endpoint.",
             "type": "string",
-            "pattern": "^(?=^[a-zA-Z0-9-]+$).{1,255}$"
+            "pattern": "^(?=^[a-zA-Z0-9-]+$).{1,255}$",
+            "relationshipRef": {
+                "typeName": "AWS::Redshift::ClusterSubnetGroup",
+                "propertyPath": "/properties/ClusterSubnetGroupName"
+            }
         },
         "Port": {
             "description": "The port number on which the cluster accepts incoming connections.",
@@ -100,11 +124,19 @@
             "properties": {
                 "VpcEndpointId": {
                     "type": "string",
-                    "description": "The connection endpoint ID for connecting an Amazon Redshift cluster through the proxy."
+                    "description": "The connection endpoint ID for connecting an Amazon Redshift cluster through the proxy.",
+                    "relationshipRef": {
+                        "typeName": "AWS::EC2::VPCEndpoint",
+                        "propertyPath": "/properties/Id"
+                    }
                 },
                 "VpcId": {
                     "type": "string",
-                    "description": "The VPC identifier that the endpoint is associated."
+                    "description": "The VPC identifier that the endpoint is associated.",
+                    "relationshipRef": {
+                        "typeName": "AWS::EC2::VPCEndpoint",
+                        "propertyPath": "/properties/VpcId"
+                    }
                 },
                 "NetworkInterfaces": {
                     "type": "array",

--- a/aws-redshift-endpointauthorization/aws-redshift-endpointauthorization.json
+++ b/aws-redshift-endpointauthorization/aws-redshift-endpointauthorization.json
@@ -9,7 +9,11 @@
         },
         "VpcId": {
             "type": "string",
-            "pattern": "^vpc-[A-Za-z0-9]{1,17}$"
+            "pattern": "^vpc-[A-Za-z0-9]{1,17}$",
+            "relationshipRef": {
+                "typeName": "AWS::EC2::VPC",
+                "propertyPath": "/properties/VpcId"
+            }
         }
     },
     "properties": {
@@ -24,7 +28,11 @@
         "ClusterIdentifier": {
             "description": "The cluster identifier.",
             "type": "string",
-            "pattern": "^(?=^[a-z][a-z0-9]*(-[a-z0-9]+)*$).{1,63}$"
+            "pattern": "^(?=^[a-z][a-z0-9]*(-[a-z0-9]+)*$).{1,63}$",
+            "relationshipRef": {
+                "typeName": "AWS::Redshift::Cluster",
+                "propertyPath": "/properties/ClusterIdentifier"
+            }
         },
         "AuthorizeTime": {
             "description": "The time (UTC) when the authorization was created.",

--- a/aws-redshift-eventsubscription/aws-redshift-eventsubscription.json
+++ b/aws-redshift-eventsubscription/aws-redshift-eventsubscription.json
@@ -35,7 +35,11 @@
         },
         "SnsTopicArn": {
             "description": "The Amazon Resource Name (ARN) of the Amazon SNS topic used to transmit the event notifications.",
-            "type": "string"
+            "type": "string",
+            "relationshipRef": {
+                "typeName": "AWS::SNS::Topic",
+                "propertyPath": "/properties/TopicArn"
+            }
         },
         "SourceType": {
             "description": "The type of source that will be generating the events.",

--- a/aws-redshift-scheduledaction/aws-redshift-scheduledaction.json
+++ b/aws-redshift-scheduledaction/aws-redshift-scheduledaction.json
@@ -8,16 +8,32 @@
             "type": "object",
             "properties": {
                 "ClusterIdentifier": {
-                    "type": "string"
+                    "type": "string",
+                    "relationshipRef": {
+                        "typeName": "AWS::Redshift::Cluster",
+                        "propertyPath": "/properties/ClusterIdentifier"
+                    }
                 },
                 "ClusterType": {
-                    "type": "string"
+                    "type": "string",
+                    "relationshipRef": {
+                        "typeName": "AWS::Redshift::Cluster",
+                        "propertyPath": "/properties/ClusterType"
+                    }
                 },
                 "NodeType": {
-                    "type": "string"
+                    "type": "string",
+                    "relationshipRef": {
+                        "typeName": "AWS::Redshift::Cluster",
+                        "propertyPath": "/properties/NodeType"
+                    }
                 },
                 "NumberOfNodes": {
-                    "type": "integer"
+                    "type": "integer",
+                    "relationshipRef": {
+                        "typeName": "AWS::Redshift::Cluster",
+                        "propertyPath": "/properties/NumberOfNodes"
+                    }
                 },
                 "Classic": {
                     "type": "boolean"
@@ -33,7 +49,11 @@
             "type": "object",
             "properties": {
                 "ClusterIdentifier": {
-                    "type": "string"
+                    "type": "string",
+                    "relationshipRef": {
+                        "typeName": "AWS::Redshift::Cluster",
+                        "propertyPath": "/properties/ClusterIdentifier"
+                    }
                 }
             },
             "required": [
@@ -46,7 +66,11 @@
             "type": "object",
             "properties": {
                 "ClusterIdentifier": {
-                    "type": "string"
+                    "type": "string",
+                    "relationshipRef": {
+                        "typeName": "AWS::Redshift::Cluster",
+                        "propertyPath": "/properties/ClusterIdentifier"
+                    }
                 }
             },
             "required": [
@@ -102,7 +126,11 @@
         },
         "IamRole": {
             "description": "The IAM role to assume to run the target action.",
-            "type": "string"
+            "type": "string",
+            "relationshipRef": {
+                "typeName": "AWS::IAM::Role",
+                "propertyPath": "/properties/Arn"
+            }
         },
         "ScheduledActionDescription": {
             "description": "The description of the scheduled action.",


### PR DESCRIPTION
Uluru has launched a campaign to update relationship references for all cloudformation resources. This campaign would require all current CFN resources to add relationship references to its attributes/properties which can be referenced as a attribute of different CFN resource. This would help uluru to identify the dependency between CFN resources.
This change contains update to all relationship references of resources that are required to deploy Redshift CFN resources. This change is required as part of Uluru campaign

[Testing]:

1. Tested CTV2 for all resources in local account.
2. Verified that CTV2 passed for all resources in the account


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
