### PR TITLE
Support CloudWatch integration for AWS::Redshift::Cluster LoggingProperties

### DIFF
--- a/aws-redshift-cluster/aws-redshift-cluster.json
+++ b/aws-redshift-cluster/aws-redshift-cluster.json
@@ -30,6 +30,17 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "LogDestinationType": {
+                    "type": "string"
+                },
+                "LogExports": {
+                    "type": "array",
+                    "insertionOrder": false,
+                    "maxItems": 3,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "BucketName": {
                     "type": "string",
                     "relationshipRef": {
@@ -143,17 +154,20 @@
         "KmsKeyId": {
             "description": "The AWS Key Management Service (KMS) key ID of the encryption key that you want to use to encrypt data in the cluster.",
             "type": "string",
-            "anyOf": [{
-                "relationshipRef": {
-                    "typeName": "AWS::KMS::Key",
-                    "propertyPath": "/properties/Arn"
+            "anyOf": [
+                {
+                    "relationshipRef": {
+                        "typeName": "AWS::KMS::Key",
+                        "propertyPath": "/properties/Arn"
+                    }
+                },
+                {
+                    "relationshipRef": {
+                        "typeName": "AWS::KMS::Key",
+                        "propertyPath": "/properties/KeyId"
+                    }
                 }
-            }, {
-                "relationshipRef": {
-                    "typeName": "AWS::KMS::Key",
-                    "propertyPath": "/properties/KeyId"
-                }
-            }]
+            ]
         },
         "NumberOfNodes": {
             "description": "The number of compute nodes in the cluster. This parameter is required when the ClusterType parameter is specified as multi-node.",
@@ -178,17 +192,20 @@
             "uniqueItems": false,
             "items": {
                 "type": "string",
-                "anyOf": [{
-                    "relationshipRef": {
-                        "typeName": "AWS::EC2::SecurityGroup",
-                        "propertyPath": "/properties/Id"
+                "anyOf": [
+                    {
+                        "relationshipRef": {
+                            "typeName": "AWS::EC2::SecurityGroup",
+                            "propertyPath": "/properties/Id"
+                        }
+                    },
+                    {
+                        "relationshipRef": {
+                            "typeName": "AWS::Redshift::ClusterSecurityGroup",
+                            "propertyPath": "/properties/Id"
+                        }
                     }
-                }, {
-                    "relationshipRef": {
-                        "typeName": "AWS::Redshift::ClusterSecurityGroup",
-                        "propertyPath": "/properties/Id"
-                    }
-                }]
+                ]
             }
         },
         "IamRoles": {
@@ -335,17 +352,20 @@
         "MasterPasswordSecretKmsKeyId": {
             "description": "The ID of the Key Management Service (KMS) key used to encrypt and store the cluster's admin user credentials secret.",
             "type": "string",
-            "anyOf": [{
-                "relationshipRef": {
-                    "typeName": "AWS::KMS::Key",
-                    "propertyPath": "/properties/Arn"
+            "anyOf": [
+                {
+                    "relationshipRef": {
+                        "typeName": "AWS::KMS::Key",
+                        "propertyPath": "/properties/Arn"
+                    }
+                },
+                {
+                    "relationshipRef": {
+                        "typeName": "AWS::KMS::Key",
+                        "propertyPath": "/properties/KeyId"
+                    }
                 }
-            }, {
-                "relationshipRef": {
-                    "typeName": "AWS::KMS::Key",
-                    "propertyPath": "/properties/KeyId"
-                }
-            }]
+            ]
         },
         "MasterPasswordSecretArn": {
             "description": "The Amazon Resource Name (ARN) for the cluster's admin user credentials secret.",

--- a/aws-redshift-cluster/docs/loggingproperties.md
+++ b/aws-redshift-cluster/docs/loggingproperties.md
@@ -8,6 +8,8 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 <pre>
 {
+    "<a href="#logdestinationtype" title="LogDestinationType">LogDestinationType</a>" : <i>String</i>,
+    "<a href="#logexports" title="LogExports">LogExports</a>" : <i>[ String, ... ]</i>,
     "<a href="#bucketname" title="BucketName">BucketName</a>" : <i>String</i>,
     "<a href="#s3keyprefix" title="S3KeyPrefix">S3KeyPrefix</a>" : <i>String</i>
 }
@@ -16,11 +18,30 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 ### YAML
 
 <pre>
+<a href="#logdestinationtype" title="LogDestinationType">LogDestinationType</a>: <i>String</i>
+<a href="#logexports" title="LogExports">LogExports</a>: <i>
+      - String</i>
 <a href="#bucketname" title="BucketName">BucketName</a>: <i>String</i>
 <a href="#s3keyprefix" title="S3KeyPrefix">S3KeyPrefix</a>: <i>String</i>
 </pre>
 
 ## Properties
+
+#### LogDestinationType
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### LogExports
+
+_Required_: No
+
+_Type_: List of String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### BucketName
 

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
@@ -74,6 +74,8 @@ public class ReadHandler extends BaseHandlerStd {
                             .makeServiceCall(this::describeLoggingStatus)
                             .done(enableLoggingResponse -> {
                                 LoggingProperties loggingProperties = LoggingProperties.builder()
+                                        .logDestinationType(enableLoggingResponse.logDestinationTypeAsString())
+                                        .logExports(enableLoggingResponse.logExports())
                                         .bucketName(enableLoggingResponse.bucketName())
                                         .s3KeyPrefix(enableLoggingResponse.s3KeyPrefix())
                                         .build();

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/Translator.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/Translator.java
@@ -128,11 +128,14 @@ public class Translator {
    * @return awsRequest the aws service request to create a resource
    */
   static EnableLoggingRequest translateToEnableLoggingRequest(final ResourceModel model) {
-    String s3KeyPrefix = model.getLoggingProperties().getS3KeyPrefix().lastIndexOf("/")
-            == model.getLoggingProperties().getS3KeyPrefix().length() - 1 ? model.getLoggingProperties().getS3KeyPrefix()
-            : model.getLoggingProperties().getS3KeyPrefix() + "/";
+    String s3KeyPrefix = model.getLoggingProperties().getS3KeyPrefix();
+    if (s3KeyPrefix != null) { // S3 key prefix can be empty if it is CW logging
+      s3KeyPrefix = s3KeyPrefix.lastIndexOf("/") == s3KeyPrefix.length() - 1 ? s3KeyPrefix : s3KeyPrefix + "/";
+    }
     return EnableLoggingRequest.builder()
             .clusterIdentifier(model.getClusterIdentifier())
+            .logDestinationType(model.getLoggingProperties().getLogDestinationType())
+            .logExports(model.getLoggingProperties().getLogExports())
             .bucketName(model.getLoggingProperties().getBucketName())
             .s3KeyPrefix(s3KeyPrefix)
             .build();
@@ -293,6 +296,8 @@ public class Translator {
    */
   static ResourceModel translateFromDescribeLoggingResponse(final DescribeLoggingStatusResponse awsResponse) {
       LoggingProperties loggingProperties = LoggingProperties.builder()
+              .logDestinationType(awsResponse.logDestinationTypeAsString())
+              .logExports(awsResponse.logExports())
               .bucketName(awsResponse.bucketName())
               .s3KeyPrefix(awsResponse.s3KeyPrefix())
               .build();

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/AbstractTestBase.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/AbstractTestBase.java
@@ -1,8 +1,11 @@
 package software.amazon.redshift.cluster;
 
+import com.google.common.collect.ImmutableList;
 import java.lang.UnsupportedOperationException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import software.amazon.awssdk.awscore.AwsRequest;
@@ -35,15 +38,18 @@ public class AbstractTestBase {
   protected static final String CLUSTER_NAMESPACE_ARN;
   protected static final String NAMESPACE_POLICY;
   protected static final String NAMESPACE_POLICY_EMPTY;
+  protected static final String LOG_DESTINATION_TYPE_CW;
   protected static final ResourcePolicy RESOURCE_POLICY;
   protected static final ResourcePolicy RESOURCE_POLICY_EMPTY;
-  protected static final LoggingProperties LOGGING_PROPERTIES;
+  protected static final LoggingProperties LOGGING_PROPERTIES_S3;
+  protected static final LoggingProperties LOGGING_PROPERTIES_CW;
   protected static final LoggingProperties LOGGING_PROPERTIES_DISABLED;
   protected static final software.amazon.awssdk.services.redshift.model.Tag TAG;
-  protected  static final Integer DEFER_MAINTENANCE_DURATION;
-  protected  static final String DEFER_MAINTENANCE_IDENTIFIER;
-  protected  static final String DEFER_MAINTENANCE_START_TIME;
-  protected  static final String DEFER_MAINTENANCE_END_TIME;
+  protected static final Integer DEFER_MAINTENANCE_DURATION;
+  protected static final String DEFER_MAINTENANCE_IDENTIFIER;
+  protected static final String DEFER_MAINTENANCE_START_TIME;
+  protected static final String DEFER_MAINTENANCE_END_TIME;
+  protected static final List<String> LOG_EXPORTS_TYPES;
 
   static {
     MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
@@ -67,6 +73,8 @@ public class AbstractTestBase {
     DEFER_MAINTENANCE_START_TIME = "2023-12-10T00:00:00Z";
     DEFER_MAINTENANCE_END_TIME = "2024-01-19T00:00:00Z";
     SNAPSHOT_IDENTIFIER = "redshift-cluster-1-snapshot";
+    LOG_DESTINATION_TYPE_CW = "cloudwatch";
+    LOG_EXPORTS_TYPES = ImmutableList.of("connectionlog", "useractivitylog", "userlog");
 
     RESOURCE_POLICY = ResourcePolicy.builder()
             .resourceArn(CLUSTER_NAMESPACE_ARN)
@@ -79,12 +87,19 @@ public class AbstractTestBase {
             .build();
 
 
-    LOGGING_PROPERTIES = LoggingProperties.builder()
+    LOGGING_PROPERTIES_S3 = LoggingProperties.builder()
             .bucketName(BUCKET_NAME)
             .s3KeyPrefix("test")
             .build();
 
+    LOGGING_PROPERTIES_CW = LoggingProperties.builder()
+            .logDestinationType(LOG_DESTINATION_TYPE_CW)
+            .logExports(LOG_EXPORTS_TYPES)
+            .build();
+
     LOGGING_PROPERTIES_DISABLED = LoggingProperties.builder()
+            .logDestinationType(null)
+            .logExports(new ArrayList<>())
             .bucketName(null)
             .s3KeyPrefix(null)
             .build();
@@ -213,6 +228,23 @@ public class AbstractTestBase {
   public static CreateClusterResponse createClusterResponseSdk() {
     return CreateClusterResponse.builder()
             .cluster(responseCluster())
+            .build();
+  }
+
+  public static EnableLoggingResponse createS3EnableLoggingResponseSdk() {
+    return EnableLoggingResponse.builder()
+            .bucketName(BUCKET_NAME)
+            .loggingEnabled(true)
+            .lastSuccessfulDeliveryTime(Instant.now())
+            .build();
+  }
+
+  public static EnableLoggingResponse createCWEnableLoggingResponseSdk() {
+    return EnableLoggingResponse.builder()
+            .logDestinationType(LOG_DESTINATION_TYPE_CW)
+            .logExports(LOG_EXPORTS_TYPES)
+            .loggingEnabled(true)
+            .lastSuccessfulDeliveryTime(Instant.now())
             .build();
   }
 

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/UpdateHandlerTest.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/UpdateHandlerTest.java
@@ -187,8 +187,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         List<String> prevModelIamRoles = Arrays.asList(IAM_ROLE_ARN, roleToRemove);
 
         LoggingProperties loggingProperties = LoggingProperties.builder()
-                .bucketName(BUCKET_NAME)
-                .s3KeyPrefix("test")
+                .logDestinationType(LOG_DESTINATION_TYPE_CW)
+                .logExports(LOG_EXPORTS_TYPES)
                 .build();
 
         List<Tag> newModelTags = Arrays.asList(tag);
@@ -303,6 +303,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getIamRoles()).isEqualTo(request.getDesiredResourceState().getIamRoles());
         assertThat(response.getResourceModel().getLoggingProperties().getBucketName()).isNull();
         assertThat(response.getResourceModel().getLoggingProperties().getS3KeyPrefix()).isNull();
+        assertThat(response.getResourceModel().getLoggingProperties().getLogDestinationType()).isNull();
+        assertThat(response.getResourceModel().getLoggingProperties().getLogExports()).isNullOrEmpty();
         assertThat(response.getResourceModel().getNumberOfNodes()).isEqualTo(previousModel.getNumberOfNodes()*2);
 
         assertThat(response.getResourceModels()).isNull();
@@ -336,8 +338,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         List<String> newModelIamRoles = Arrays.asList(IAM_ROLE_ARN, roleToAdd);
 
         LoggingProperties loggingProperties = LoggingProperties.builder()
-                .bucketName(BUCKET_NAME)
-                .s3KeyPrefix("test/")
+                .logDestinationType(LOG_DESTINATION_TYPE_CW)
+                .logExports(LOG_EXPORTS_TYPES)
                 .build();
 
         ResourceModel updateModel = BASIC_MODEL.toBuilder()
@@ -419,8 +421,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().describeLoggingStatus(any(DescribeLoggingStatusRequest.class)))
                 .thenReturn(DescribeLoggingStatusResponse.builder()
                         .loggingEnabled(true)
-                        .bucketName(BUCKET_NAME)
-                        .s3KeyPrefix("test/")
+                        .logDestinationType(LOG_DESTINATION_TYPE_CW)
+                        .logExports(LOG_EXPORTS_TYPES)
                         .build());
         //call back
         response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-redshift/issues/104

*Description of changes:*
This change provides CFN support for enabling redshift audit logging with CloudWatch. We are adding 2 new parameters "LogDestinationType" and "LogExports" to the existing schema, which are used to setup CloudWatch logging for audit logging.

Manual testing and integration testing have been performed on cloudformation with all new changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
