### PR TITLE
Skip calling describe-clusters for cross-account integration

### DIFF
--- a/aws-redshift-integration/pom.xml
+++ b/aws-redshift-integration/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-core</artifactId>
-            <version>2.21.44</version>
+            <version>2.28.26</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-redshift-integration/src/test/java/software/amazon/redshift/integration/BaseHandlerTest.java
+++ b/aws-redshift-integration/src/test/java/software/amazon/redshift/integration/BaseHandlerTest.java
@@ -1,0 +1,25 @@
+package software.amazon.redshift.integration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+public class BaseHandlerTest extends AbstractTestBase {
+    @Test
+    public void isCrossAccountIntegration() {
+        ResourceModel model = ResourceModel.builder()
+                .sourceArn("arn:aws-cn:dynamodb:us-west-2:123123123123:table/test")
+                .targetArn("arn:aws-cn:redshift:us-west-2:897123123123:namespace:1231224dsfasdfwer")
+                .build();
+        assertTrue(BaseHandlerStd.isCrossAccountIntegration(model));
+        ResourceModel sameAccountModel = ResourceModel.builder()
+                .sourceArn("arn:aws-cn:dynamodb:us-west-2:123123123123:table/test")
+                .targetArn("arn:aws-cn:redshift:us-west-2:123123123123:namespace:1231224dsfasdfwer")
+                .build();
+        assertFalse(BaseHandlerStd.isCrossAccountIntegration(sameAccountModel));
+    }
+}


### PR DESCRIPTION
The previous logic checks if the target cluster is stable by calling describe-clusters. In cross-account integration setup, the target might not have permission to call the API, in which case, we'll wait for 1 minute for the cluster to become available (usually takes a few seconds)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
