### PR TITLE
Secret Deletion Stabilization Added to Redshift Cluster resource

### DIFF
--- a/aws-redshift-cluster/.rpdk-config
+++ b/aws-redshift-cluster/.rpdk-config
@@ -15,5 +15,8 @@
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
     },
-    "executableEntrypoint": "software.amazon.redshift.cluster.HandlerWrapperExecutable"
+    "logProcessorEnabled": "true",
+    "executableEntrypoint": "software.amazon.redshift.cluster.HandlerWrapperExecutable",
+    "contractSettings": {},
+    "canarySettings": {}
 }

--- a/aws-redshift-cluster/aws-redshift-cluster.json
+++ b/aws-redshift-cluster/aws-redshift-cluster.json
@@ -414,6 +414,7 @@
             "permissions": [
                 "iam:PassRole",
                 "iam:CreateServiceLinkedRole",
+                "kms:*",
                 "redshift:DescribeClusters",
                 "redshift:CreateCluster",
                 "redshift:RestoreFromClusterSnapshot",
@@ -443,7 +444,11 @@
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeNetworkAcls",
                 "ec2:DescribeRouteTables",
-                "cloudwatch:PutMetricData"
+                "cloudwatch:PutMetricData",
+                "secretsmanager:CreateSecret",
+                "secretsmanager:TagResource",
+                "secretsmanager:RotateSecret",
+                "secretsmanager:DescribeSecret"
             ],
             "timeoutInMinutes": 2160
         },
@@ -460,6 +465,7 @@
         "update": {
             "permissions": [
                 "iam:PassRole",
+                "kms:*",
                 "redshift:DescribeClusters",
                 "redshift:ModifyCluster",
                 "redshift:ModifyClusterIamRoles",
@@ -485,7 +491,13 @@
                 "redshift:PutResourcePolicy",
                 "redshift:GetResourcePolicy",
                 "redshift:DeleteResourcePolicy",
-                "cloudwatch:PutMetricData"
+                "cloudwatch:PutMetricData",
+                "secretsmanager:CreateSecret",
+                "secretsmanager:TagResource",
+                "secretsmanager:RotateSecret",
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:UpdateSecret",
+                "secretsmanager:DeleteSecret"
             ],
             "timeoutInMinutes": 2160
         },
@@ -493,7 +505,11 @@
             "permissions": [
                 "redshift:DescribeTags",
                 "redshift:DescribeClusters",
-                "redshift:DeleteCluster"
+                "redshift:DeleteCluster",
+                "redshift:DeleteResourcePolicy",
+                "kms:RetireGrant",
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:DeleteSecret"
             ],
             "timeoutInMinutes": 2160
         },

--- a/aws-redshift-cluster/docs/README.md
+++ b/aws-redshift-cluster/docs/README.md
@@ -447,9 +447,9 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### SnapshotCopyRetentionPeriod
 
-The number of days to retain automated snapshots in the destination region after they are copied from the source region.
+The number of days to retain automated snapshots in the destination region after they are copied from the source region. 
 
- Default is 7.
+ Default is 7. 
 
  Constraints: Must be at least 1 and no more than 35.
 
@@ -701,3 +701,4 @@ The Amazon Resource Name (ARN) of the cluster namespace.
 #### MasterPasswordSecretArn
 
 The Amazon Resource Name (ARN) for the cluster's admin user credentials secret.
+

--- a/aws-redshift-cluster/docs/endpoint.md
+++ b/aws-redshift-cluster/docs/endpoint.md
@@ -17,3 +17,4 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 </pre>
 
 ## Properties
+

--- a/aws-redshift-cluster/docs/loggingproperties.md
+++ b/aws-redshift-cluster/docs/loggingproperties.md
@@ -58,3 +58,4 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-redshift-cluster/docs/tag.md
+++ b/aws-redshift-cluster/docs/tag.md
@@ -51,3 +51,4 @@ _Minimum Length_: <code>1</code>
 _Maximum Length_: <code>255</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-redshift-cluster/pom.xml
+++ b/aws-redshift-cluster/pom.xml
@@ -25,6 +25,12 @@
             <artifactId>redshift</artifactId>
             <version>2.21.44</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/secretsmanager -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+            <version>2.22.5</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>

--- a/aws-redshift-cluster/resource-role.yaml
+++ b/aws-redshift-cluster/resource-role.yaml
@@ -52,6 +52,8 @@ Resources:
                 - "ec2:ModifyVpcEndpoint"
                 - "iam:CreateServiceLinkedRole"
                 - "iam:PassRole"
+                - "kms:*"
+                - "kms:RetireGrant"
                 - "redshift:CreateCluster"
                 - "redshift:CreateTags"
                 - "redshift:DeleteCluster"
@@ -81,6 +83,12 @@ Resources:
                 - "redshift:RestoreFromClusterSnapshot"
                 - "redshift:ResumeCluster"
                 - "redshift:RotateEncryptionKey"
+                - "secretsmanager:CreateSecret"
+                - "secretsmanager:DeleteSecret"
+                - "secretsmanager:DescribeSecret"
+                - "secretsmanager:RotateSecret"
+                - "secretsmanager:TagResource"
+                - "secretsmanager:UpdateSecret"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/CallbackContext.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/CallbackContext.java
@@ -8,6 +8,7 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
     String namespaceArn = null;
+    String masterPasswordSecretArn = null;
     LoggingProperties loggingProperties;
     boolean callBackForReboot = false;
     boolean callBackForDelete = false;
@@ -21,9 +22,18 @@ public class CallbackContext extends StdCallbackContext {
     boolean callbackAfterClusterRestore = false;
     boolean callbackAfterAfterClusterParameterGroupNameModify = false;
 
+
     public void setNamespaceArn(String namespaceArn) {this.namespaceArn = namespaceArn; }
 
     public String getNamespaceArn() { return namespaceArn; }
+
+    public String getMasterPasswordSecretArn() {
+        return masterPasswordSecretArn;
+    }
+
+    public void setMasterPasswordSecretArn(String masterPasswordSecretArn) {
+        this.masterPasswordSecretArn = masterPasswordSecretArn;
+    }
 
     public void setLoggingProperties(LoggingProperties loggingProperties) {
         this.loggingProperties = loggingProperties;

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ClientBuilder.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ClientBuilder.java
@@ -1,11 +1,18 @@
 package software.amazon.redshift.cluster;
 
 import software.amazon.awssdk.services.redshift.RedshiftClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
 public class ClientBuilder {
   static RedshiftClient getClient() {
     return RedshiftClient.builder()
+            .httpClient(LambdaWrapper.HTTP_CLIENT)
+            .build();
+  }
+
+  public static SecretsManagerClient secretsManagerClient() {
+    return SecretsManagerClient.builder()
             .httpClient(LambdaWrapper.HTTP_CLIENT)
             .build();
   }

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/CreateHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/CreateHandler.java
@@ -51,6 +51,7 @@ import software.amazon.awssdk.services.redshift.model.SnapshotScheduleNotFoundEx
 import software.amazon.awssdk.services.redshift.model.TagLimitExceededException;
 import software.amazon.awssdk.services.redshift.model.UnauthorizedOperationException;
 import software.amazon.awssdk.services.redshift.model.UnsupportedOperationException;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
@@ -78,6 +79,7 @@ public class CreateHandler extends BaseHandlerStd {
         final ResourceHandlerRequest<ResourceModel> request,
         final CallbackContext callbackContext,
         final ProxyClient<RedshiftClient> proxyClient,
+        final ProxyClient<SecretsManagerClient> secretsManagerProxyClient,
         final Logger logger) {
 
         this.logger = logger;
@@ -162,7 +164,7 @@ public class CreateHandler extends BaseHandlerStd {
                     }
                     return progress;
                 })
-                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, secretsManagerProxyClient, logger));
     }
 
     private RestoreFromClusterSnapshotResponse restoreFromClusterSnapshot(

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/ReadHandler.java
@@ -19,6 +19,7 @@ import software.amazon.awssdk.services.redshift.model.RedshiftException;
 import software.amazon.awssdk.services.redshift.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.redshift.model.ResourcePolicy;
 import software.amazon.awssdk.services.redshift.model.UnsupportedOperationException;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
@@ -29,6 +30,7 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
 
 public class ReadHandler extends BaseHandlerStd {
     private Logger logger;
@@ -45,6 +47,7 @@ public class ReadHandler extends BaseHandlerStd {
         final ResourceHandlerRequest<ResourceModel> request,
         final CallbackContext callbackContext,
         final ProxyClient<RedshiftClient> proxyClient,
+        final ProxyClient<SecretsManagerClient> secretsManagerProxyClient,
         final Logger logger) {
 
         this.logger = logger;

--- a/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/UpdateHandler.java
+++ b/aws-redshift-cluster/src/main/java/software/amazon/redshift/cluster/UpdateHandler.java
@@ -87,6 +87,7 @@ import software.amazon.awssdk.services.redshift.model.UnauthorizedOperationExcep
 import software.amazon.awssdk.services.redshift.model.UnknownSnapshotCopyRegionException;
 import software.amazon.awssdk.services.redshift.model.UnsupportedOperationException;
 import software.amazon.awssdk.services.redshift.model.UnsupportedOptionException;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
@@ -174,6 +175,7 @@ public class UpdateHandler extends BaseHandlerStd {
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
             final ProxyClient<RedshiftClient> proxyClient,
+            final ProxyClient<SecretsManagerClient> secretsManagerProxyClient,
             final Logger logger) {
 
         this.logger = logger;
@@ -508,7 +510,7 @@ public class UpdateHandler extends BaseHandlerStd {
                     }
                     return progress;
                 })
-                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, secretsManagerProxyClient, logger));
         }
 
     private DescribeClustersResponse describeCluster (

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/CreateHandlerTest.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/CreateHandlerTest.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.services.redshift.model.ModifyClusterMaintenanceRe
 import software.amazon.awssdk.services.redshift.model.PutResourcePolicyRequest;
 import software.amazon.awssdk.services.redshift.model.RestoreFromClusterSnapshotRequest;
 import software.amazon.awssdk.services.redshift.model.RestoreFromClusterSnapshotResponse;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -55,6 +56,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Mock
     private ProxyClient<RedshiftClient> proxyClient;
+
+    @Mock
+    private ProxyClient<SecretsManagerClient> secretsManagerProxyClient;
 
     @Mock
     RedshiftClient sdkClient;
@@ -117,7 +121,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .thenReturn(DescribeLoggingStatusResponse.builder().loggingEnabled(false).build());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         response.getResourceModel().setMasterUserPassword(MASTER_USERPASSWORD);
 
@@ -125,7 +129,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -209,13 +213,13 @@ public class CreateHandlerTest extends AbstractTestBase {
     }
 
     private void handleRequestAndVerifyEnableLogging(ResourceHandlerRequest<ResourceModel> request) {
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -280,7 +284,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .thenReturn(DescribeLoggingStatusResponse.builder().loggingEnabled(false).build());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         response.getResourceModel().setMasterUserPassword(MASTER_USERPASSWORD);
 
@@ -288,7 +292,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -329,13 +333,13 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().describeLoggingStatus(any(DescribeLoggingStatusRequest.class)))
                 .thenReturn(DescribeLoggingStatusResponse.builder().loggingEnabled(false).build());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -376,13 +380,13 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().describeLoggingStatus(any(DescribeLoggingStatusRequest.class)))
                 .thenReturn(DescribeLoggingStatusResponse.builder().loggingEnabled(false).build());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -422,13 +426,13 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .thenReturn(DescribeLoggingStatusResponse.builder().loggingEnabled(false).build());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -474,13 +478,13 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .thenReturn(DescribeLoggingStatusResponse.builder().loggingEnabled(false).build());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/ReadHandlerTest.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/ReadHandlerTest.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.redshift.model.DescribeLoggingStatusRespo
 import software.amazon.awssdk.services.redshift.model.Endpoint;
 import software.amazon.awssdk.services.redshift.model.GetResourcePolicyRequest;
 import software.amazon.awssdk.services.redshift.model.VpcSecurityGroupMembership;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static software.amazon.redshift.cluster.TestUtils.MASTER_PASSWORD_SECRET_ARN;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractTestBase {
@@ -42,6 +44,9 @@ public class ReadHandlerTest extends AbstractTestBase {
 
     @Mock
     private ProxyClient<RedshiftClient> proxyClient;
+
+    @Mock
+    private ProxyClient<SecretsManagerClient> secretsManagerProxyClient;
 
     @Mock
     RedshiftClient sdkClient;
@@ -74,7 +79,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         when(proxyClient.client().describeLoggingStatus(any(DescribeLoggingStatusRequest.class))).thenReturn(describeLoggingStatusFalseResponseSdk());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         response.getResourceModel().setLoggingProperties(LOGGING_PROPERTIES_DISABLED);
 
@@ -150,7 +155,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(BASIC_MODEL)
                 .build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         response.getResourceModel().setMasterUserPassword(MASTER_USERPASSWORD);
 
@@ -177,7 +182,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         when(proxyClient.client().describeLoggingStatus(any(DescribeLoggingStatusRequest.class))).thenReturn(describeLoggingStatusFalseResponseSdk());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getResourcePolicyResponseSdk());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         response.getResourceModel().setLoggingProperties(LOGGING_PROPERTIES_DISABLED);
 

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/TestUtils.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/TestUtils.java
@@ -14,6 +14,7 @@ public class TestUtils {
     final static String AWS_PARTITION = "aws";
     final static String AWS_ACCOUNT_ID ="1111";
     final static String CLUSTER_IDENTIFIER = "redshift-cluster-1";
+    final static String CLUSTER_NAMESPACE_UUID = "a1234-b5678";
     final static String CLUSTER_IDENTIFIER_COMPLETE = "redshift-cluster-2";
     final static String MASTER_USERNAME = "master";
     final static String MASTER_USERPASSWORD = "Test1234";
@@ -26,7 +27,7 @@ public class TestUtils {
     final static String MULTIAZ_ENABLED = "Enabled";
     final static String MULTIAZ_DISABLED = "Disabled";
     final static String MASTER_PASSWORD_SECRET_KMS_KEY_ID = "master-password-secret-kms-key-id";
-    final static String MASTER_PASSWORD_SECRET_ARN = "secret-arn";
+    final static String MASTER_PASSWORD_SECRET_ARN = "arn:aws:secretsmanager:" + AWS_REGION + ":" + AWS_ACCOUNT_ID + ":secret/" + CLUSTER_NAMESPACE_UUID;
 
     final static Cluster BASIC_CLUSTER = Cluster.builder()
             .clusterStatus("available")

--- a/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/UpdateHandlerTest.java
+++ b/aws-redshift-cluster/src/test/java/software/amazon/redshift/cluster/UpdateHandlerTest.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.services.redshift.model.PutResourcePolicyResponse;
 import software.amazon.awssdk.services.redshift.model.ResizeClusterRequest;
 import software.amazon.awssdk.services.redshift.model.ResizeClusterResponse;
 import software.amazon.awssdk.services.redshift.model.ResourcePolicy;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -78,6 +79,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
     private ProxyClient<RedshiftClient> proxyClient;
 
     @Mock
+    private ProxyClient<SecretsManagerClient> secretsManagerProxyClient;
+
+    @Mock
     RedshiftClient sdkClient;
 
     static UpdateHandler handler;
@@ -115,7 +119,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().describeLoggingStatus(any(DescribeLoggingStatusRequest.class))).thenReturn(describeLoggingStatusFalseResponseSdk());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -158,7 +162,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .resourcePolicy(newResourcePolicy)
                 .build());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         request.getDesiredResourceState().setMasterUserPassword(null);
         assertThat(response).isNotNull();
@@ -281,7 +285,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         // verify that ARN is correctly constructed
         ArgumentCaptor<DeleteTagsRequest> deleteTagsRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteTagsRequest.class);
@@ -293,7 +297,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -412,7 +416,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .build());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
@@ -425,7 +429,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .logExports(LOG_EXPORTS_TYPES)
                         .build());
         //call back
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -475,13 +479,13 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -567,13 +571,13 @@ public class UpdateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -617,13 +621,13 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .build());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -673,13 +677,13 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .build());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -728,13 +732,13 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .build());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -840,13 +844,13 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .build());
         when(proxyClient.client().getResourcePolicy(any(GetResourcePolicyRequest.class))).thenReturn(getEmptyResourcePolicyResponseSdk());
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
 
-        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, logger);
+        response = handler.handleRequest(proxy, request, response.getCallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -914,7 +918,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .cluster(modifiedCluster)
                         .build());
 
-        handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, secretsManagerProxyClient, logger);
 
         if (Objects.equals(expectedModifyTrackName, NO_TEST_FLAG)) {
             if (shouldCallModifyCluster) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

As part of managed passwords feature we are creating Secrets Manager secret. This secret is deleted when a cluster resource is deleted which is an async operation. Since this secret sometimes takes longer to delete cluster contract tests fail with secret already exists error. The stabilization calls improve the stabilization of cluster.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
