### PR TITLE
Added ra3.large to list of supported node types

### DIFF
--- a/aws-redshift-cluster/aws-redshift-cluster.json
+++ b/aws-redshift-cluster/aws-redshift-cluster.json
@@ -87,7 +87,7 @@
             "maxLength": 64
         },
         "NodeType": {
-            "description": "The node type to be provisioned for the cluster.Valid Values: ds2.xlarge | ds2.8xlarge | dc1.large | dc1.8xlarge | dc2.large | dc2.8xlarge | ra3.4xlarge | ra3.16xlarge",
+            "description": "The node type to be provisioned for the cluster.Valid Values: ds2.xlarge | ds2.8xlarge | dc1.large | dc1.8xlarge | dc2.large | dc2.8xlarge | ra3.large | ra3.4xlarge | ra3.16xlarge",
             "type": "string"
         },
         "AllowVersionUpgrade": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Redshift now supports ra3.large nodeType.
https://aws.amazon.com/about-aws/whats-new/2024/10/amazon-redshift-ra3-large/

This CR contains change to include the ra3.large as list of allowed node types. This is blocking CDK to allow the node type on their end as they refer to the schema on CFN end.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
