### PR TITLE
Tags support added for cluster parameter group

### DIFF
--- a/aws-redshift-clusterparametergroup/aws-redshift-clusterparametergroup.json
+++ b/aws-redshift-clusterparametergroup/aws-redshift-clusterparametergroup.json
@@ -77,7 +77,16 @@
         }
     },
     "tagging": {
-        "taggable": true
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": true,
+        "cloudFormationSystemTags": false,
+        "tagProperty": "/properties/Tags",
+        "permissions": [
+            "redshift:DescribeTags",
+            "redshift:CreateTags",
+            "redshift:DeleteTags"
+        ]
     },
     "required": [
         "Description",
@@ -90,11 +99,6 @@
     ],
     "primaryIdentifier": [
         "/properties/ParameterGroupName"
-    ],
-    "writeOnlyProperties": [
-        "/properties/Tags",
-        "/properties/Tags/*/Key",
-        "/properties/Tags/*/Value"
     ],
     "handlers": {
         "create": {
@@ -140,6 +144,7 @@
         "delete": {
             "permissions": [
                 "redshift:DescribeTags",
+                "redshift:DeleteTags",
                 "redshift:DescribeClusterParameterGroups",
                 "redshift:DeleteClusterParameterGroup",
                 "redshift:DescribeClusterParameters",

--- a/aws-redshift-clusterparametergroup/resource-role.yaml
+++ b/aws-redshift-clusterparametergroup/resource-role.yaml
@@ -49,6 +49,7 @@ Resources:
                 - "redshift:DeleteClusterParameterGroup"
                 - "redshift:DeleteTags"
                 - "redshift:DescribeClusterParameterGroups"
+                - "redshift:DescribeClusterParameters"
                 - "redshift:DescribeTags"
                 - "redshift:ModifyClusterParameterGroup"
                 - "redshift:ResetClusterParameterGroup"

--- a/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/BaseHandlerStd.java
+++ b/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/BaseHandlerStd.java
@@ -4,13 +4,21 @@ import com.amazonaws.util.StringUtils;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.awssdk.services.redshift.model.DescribeTagsRequest;
+import software.amazon.awssdk.services.redshift.model.DescribeTagsResponse;
+import software.amazon.awssdk.services.redshift.model.CreateTagsResponse;
+import software.amazon.awssdk.services.redshift.model.InvalidTagException;
+import software.amazon.awssdk.services.redshift.model.InvalidClusterStateException;
+import software.amazon.awssdk.services.redshift.model.ResourceNotFoundException;
 
 // Placeholder for the functionality that could be shared across Create/Read/Update/Delete/List Handlers
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
+    protected Logger logger;
     protected static final String CALL_GRAPH_TYPE_NAME = StringUtils.replace(ResourceModel.TYPE_NAME, "::", "-");
 
     @Override
@@ -34,4 +42,54 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final CallbackContext callbackContext,
             final ProxyClient<RedshiftClient> proxyClient,
             final Logger logger);
+
+    protected DescribeTagsResponse readTags(final DescribeTagsRequest awsRequest,
+                                          final ProxyClient<RedshiftClient> proxyClient) {
+        DescribeTagsResponse awsResponse;
+        awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::describeTags);
+        logger.log(awsResponse.toString());
+        logger.log(String.format("%s's tags have successfully been read.", ResourceModel.TYPE_NAME));
+        return awsResponse;
+    }
+
+    protected CreateTagsResponse updateTags(final ModifyTagsRequest awsRequest,
+                                          final ProxyClient<RedshiftClient> proxyClient) {
+        CreateTagsResponse awsResponse = null;
+
+        if (awsRequest.getDeleteOldTagsRequest().tagKeys().isEmpty()) {
+            logger.log(String.format("No tags would be deleted for the resource: %s.", ResourceModel.TYPE_NAME));
+
+        } else {
+            proxyClient.injectCredentialsAndInvokeV2(awsRequest.getDeleteOldTagsRequest(), proxyClient.client()::deleteTags);
+            logger.log(String.format("Delete tags for the resource: %s.", ResourceModel.TYPE_NAME));
+        }
+
+        if (awsRequest.getCreateNewTagsRequest().tags().isEmpty()) {
+            logger.log(String.format("No tags would be created for the resource: %s.", ResourceModel.TYPE_NAME));
+
+        } else {
+            awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest.getCreateNewTagsRequest(), proxyClient.client()::createTags);
+            logger.log(String.format("Create tags for the resource: %s.", ResourceModel.TYPE_NAME));
+        }
+
+        return awsResponse;
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> operateTagsErrorHandler(final Object awsRequest,
+                                                                                  final Exception exception,
+                                                                                  final ProxyClient<RedshiftClient> client,
+                                                                                  final ResourceModel model,
+                                                                                  final CallbackContext context) {
+        if (exception instanceof ResourceNotFoundException) {
+            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.NotFound);
+
+        } else if (exception instanceof InvalidTagException ||
+                exception instanceof InvalidClusterStateException) {
+            return ProgressEvent.defaultFailureHandler(exception, HandlerErrorCode.InvalidRequest);
+
+        } else {
+            return ProgressEvent.failed(model, context, HandlerErrorCode.UnauthorizedTaggingOperation, exception.getMessage());
+        }
+    }
+
 }

--- a/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/CreateHandler.java
+++ b/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/CreateHandler.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Maps;
 
 public class CreateHandler extends BaseHandlerStd {
     private static final int MAX_CLUSTER_PARAMETER_GROUP_NAME_LENGTH = 255;
-    private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,

--- a/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/DeleteHandler.java
+++ b/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/DeleteHandler.java
@@ -13,7 +13,6 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class DeleteHandler extends BaseHandlerStd {
-    private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,

--- a/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/Translator.java
+++ b/aws-redshift-clusterparametergroup/src/main/java/software/amazon/redshift/clusterparametergroup/Translator.java
@@ -160,13 +160,14 @@ public class Translator {
      * @param awsResponse the aws service describe resource response
      * @return awsRequest the aws service request to update tags of a resource
      */
-    static ResourceModel translateFromReadTagsResponse(final DescribeTagsResponse awsResponse) {
-        return ResourceModel.builder()
-                .tags(translateToModelTags(awsResponse.taggedResources()
+    static ResourceModel translateFromReadTagsResponse(final ResourceModel model,
+                                                       final DescribeTagsResponse awsResponse) {
+        model.setTags(translateToModelTags(awsResponse.taggedResources()
                         .stream()
                         .map(TaggedResource::tag)
-                        .collect(Collectors.toList())))
-                .build();
+                        .collect(Collectors.toList())));
+        return model;
+
     }
 
     /**

--- a/aws-redshift-clusterparametergroup/src/test/java/software/amazon/redshift/clusterparametergroup/CreateHandlerTest.java
+++ b/aws-redshift-clusterparametergroup/src/test/java/software/amazon/redshift/clusterparametergroup/CreateHandlerTest.java
@@ -10,6 +10,8 @@ import software.amazon.awssdk.services.redshift.model.CreateClusterParameterGrou
 import software.amazon.awssdk.services.redshift.model.CreateClusterParameterGroupResponse;
 import software.amazon.awssdk.services.redshift.model.CreateTagsRequest;
 import software.amazon.awssdk.services.redshift.model.CreateTagsResponse;
+import software.amazon.awssdk.services.redshift.model.DeleteTagsRequest;
+import software.amazon.awssdk.services.redshift.model.DeleteTagsResponse;
 import software.amazon.awssdk.services.redshift.model.DescribeClusterParameterGroupsRequest;
 import software.amazon.awssdk.services.redshift.model.DescribeClusterParameterGroupsResponse;
 import software.amazon.awssdk.services.redshift.model.DescribeClusterParametersRequest;
@@ -31,6 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 import static software.amazon.redshift.clusterparametergroup.TestUtils.AWS_REGION;
 import static software.amazon.redshift.clusterparametergroup.TestUtils.CLUSTER_PARAMETER_GROUP;
 import static software.amazon.redshift.clusterparametergroup.TestUtils.COMPLETE_MODEL;
@@ -103,6 +106,8 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client()).createClusterParameterGroup(any(CreateClusterParameterGroupRequest.class));
+        verify(proxyClient.client(), times(2)).describeTags(any(DescribeTagsRequest.class));
         verify(proxyClient.client()).describeClusterParameterGroups(any(DescribeClusterParameterGroupsRequest.class));
+
     }
 }

--- a/aws-redshift-clusterparametergroup/src/test/java/software/amazon/redshift/clusterparametergroup/ReadHandlerTest.java
+++ b/aws-redshift-clusterparametergroup/src/test/java/software/amazon/redshift/clusterparametergroup/ReadHandlerTest.java
@@ -10,6 +10,8 @@ import software.amazon.awssdk.services.redshift.model.DescribeClusterParameterGr
 import software.amazon.awssdk.services.redshift.model.DescribeClusterParameterGroupsResponse;
 import software.amazon.awssdk.services.redshift.model.DescribeClusterParametersRequest;
 import software.amazon.awssdk.services.redshift.model.DescribeClusterParametersResponse;
+import software.amazon.awssdk.services.redshift.model.DescribeTagsRequest;
+import software.amazon.awssdk.services.redshift.model.DescribeTagsResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -26,6 +28,7 @@ import static software.amazon.redshift.clusterparametergroup.TestUtils.AWS_REGIO
 import static software.amazon.redshift.clusterparametergroup.TestUtils.CLUSTER_PARAMETER_GROUP;
 import static software.amazon.redshift.clusterparametergroup.TestUtils.COMPLETE_MODEL;
 import static software.amazon.redshift.clusterparametergroup.TestUtils.DESIRED_RESOURCE_TAGS;
+import static software.amazon.redshift.clusterparametergroup.TestUtils.DESCRIBE_TAGS_RESPONSE_CREATING;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractTestBase {
@@ -57,6 +60,9 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .thenReturn(DescribeClusterParameterGroupsResponse.builder()
                         .parameterGroups(CLUSTER_PARAMETER_GROUP)
                         .build());
+
+        when(proxyClient.client().describeTags(any(DescribeTagsRequest.class)))
+                .thenReturn(DESCRIBE_TAGS_RESPONSE_CREATING);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)

--- a/aws-redshift-clusterparametergroup/template.yml
+++ b/aws-redshift-clusterparametergroup/template.yml
@@ -13,11 +13,11 @@ Resources:
     Properties:
       Handler: software.amazon.redshift.clusterparametergroup.HandlerWrapper::handleRequest
       Runtime: java17
-      CodeUri: ./target/aws-redshift-clusterparametergroup-handler-1.0-SNAPSHOT.jar
+      CodeUri: ./target/aws-redshift-clusterparametergroup-1.0.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.redshift.clusterparametergroup.HandlerWrapper::testEntrypoint
       Runtime: java17
-      CodeUri: ./target/aws-redshift-clusterparametergroup-handler-1.0-SNAPSHOT.jar
+      CodeUri: ./target/aws-redshift-clusterparametergroup-1.0.jar


### PR DESCRIPTION
[Motivation]:
As part of the new initiative to support RBAC policies using Tags every resource on CFN need to support tags and should throw the appropriate errors in case of permission issues with creating/updating tags. This CR provides the integration for that change

[Testing]:
1. Verified that beta CT for tags are passing as suggested in the doc
2. Tested that local handlers are returning the response as expected

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
